### PR TITLE
Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ var CodeGen = require('swagger-js-codegen').CodeGen;
 var file = 'swagger/spec.json';
 var swagger = JSON.parse(fs.readFileSync(file, 'UTF-8'));
 var nodejsSourceCode = CodeGen.getNodeCode({ className: 'Test', swagger: swagger }); 
-var angularjsSourceCode = CodeGen.getNodeCode({ className: 'Test', swagger: swagger }); 
+var angularjsSourceCode = CodeGen.getAngularCode({ className: 'Test', swagger: swagger }); 
+console.log(nodejsSourceCode);
 console.log(angularjsSourceCode);
 ```
 


### PR DESCRIPTION
The previous readme had 2 node.js examples and no actual AngularJS example output. I modified the README to include an AngularJS example and to log both the Node and Angular examples to the output window. Might want to update the NPM page here, too: https://www.npmjs.org/package/swagger-js-codegen. 
