### PR TITLE
Use operationId parameter for method name in swagger 2.0 specs

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -45,7 +45,7 @@ var getViewForSwagger2 = function(opts, type){
             var method = {
                 path: path,
                 className: opts.className,
-                methodName: getPathToMethodName(m, path),
+                methodName: op.operationId ? op.operationId : getPathToMethodName(m, path),
                 method: m.toUpperCase(),
                 isGET: m.toUpperCase() === 'GET',
                 summary: op.description,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swagger-js-codegen",
   "main": "./lib/codegen.js",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A Swagger codegen for JavaScript",
   "scripts": {
     "test": "grunt"


### PR DESCRIPTION
fixes #32
