### PR TITLE
documentation enhancements

### DIFF
--- a/templates/angular-class.mustache
+++ b/templates/angular-class.mustache
@@ -6,9 +6,12 @@ angular.module('{{&moduleName}}', [])
     
     /**
      * {{&description}}
-     * @class " || {{&className}} || "
-     * @param {string} domain - The project domain
-     * @param {string} cache - An angularjs cache implementation
+     * @class {{&className}}
+     * @param {(string|object)} [domainOrOptions] - The project domain or options object. If object, see the object's optional properties.
+     * @param {string} [domainOrOptions.domain] - The project domain
+     * @param {string} [domainOrOptions.cache] - An angularjs cache implementation
+     * @param {object} [domainOrOptions.token] - auth token - object with value property and optional headerOrQueryName and isQuery properties
+     * @param {string} [cache] - An angularjs cache implementation
      */
     var {{&className}} = (function(){
         function {{&className}}(options, cache){
@@ -40,6 +43,15 @@ angular.module('{{&moduleName}}', [])
         };
 
         {{#isSecure}}
+            /**
+             * Set Token
+             * @method
+             * @name {{&className}}#setToken
+             * @param {string} value - token's value
+             * @param {string} headerOrQueryName - the header or query name to send the token at
+             * @param {boolean} isQuery - true if send the token as query param, otherwise, send as header param
+             *
+             */
             {{&className}}.prototype.setToken = function (value, headerOrQueryName, isQuery) {
                 this.token.value = value;
                 this.token.headerOrQueryName = headerOrQueryName;

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -3,7 +3,7 @@
  * @method
  * @name {{&className}}#{{&methodName}}
 {{#parameters}}
-{{^isSingleton}} * @param {{=<% %>=}}{{<%&type%>}}<%={{ }}=%> {{&camelCaseName}} - {{&description}}{{/isSingleton}}
+{{^isSingleton}} * @param {{=<% %>=}}{<%&type%>}<%={{ }}=%> {{&camelCaseName}} - {{&description}}{{/isSingleton}}
 {{/parameters}}
  * 
  */

--- a/templates/node-class.mustache
+++ b/templates/node-class.mustache
@@ -2,7 +2,9 @@
 /**
  * {{&description}}
  * @class {{&className}}
- * @param {string} domain - The project domain
+ * @param {(string|object)} [domainOrOptions] - The project domain or options object. If object, see the object's optional properties.
+ * @param {string} [domainOrOptions.domain] - The project domain
+ * @param {object} [domainOrOptions.token] - auth token - object with value property and optional headerOrQueryName and isQuery properties
  */
 var {{&className}} = (function(){
     'use strict';
@@ -22,6 +24,15 @@ var {{&className}} = (function(){
     }
 
     {{#isSecure}}
+        /**
+         * Set Token
+         * @method
+         * @name {{&className}}#setToken
+         * @param {string} value - token's value
+         * @param {string} headerOrQueryName - the header or query name to send the token at
+         * @param {boolean} isQuery - true if send the token as query param, otherwise, send as header param
+         *
+         */
         {{&className}}.prototype.setToken = function (value, headerOrQueryName, isQuery) {
             this.token.value = value;
             this.token.headerOrQueryName = headerOrQueryName;


### PR DESCRIPTION
Hey,

I addressed the following issues:
1. add documentation to setToken.
2. add documentation to the new options param in constructor.
3. fix class name in angular client - jsdoc didn't understand the previous one.
4. method's param type with one curly brackets instead of two - jsdoc expects one curly brackets wrapper in order to understand the type.