### PR TITLE
Changes implemented are as follows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #Swagger to JS Codegen
 [![Build Status](http://img.shields.io/travis/wcandillon/swagger-js-codegen/master.svg?style=flat)](https://travis-ci.org/wcandillon/swagger-js-codegen) [![NPM version](http://img.shields.io/npm/v/swagger-js-codegen.svg?style=flat)](http://badge.fury.io/js/swagger-js-codegen) [![Code Climate](http://img.shields.io/codeclimate/github/wcandillon/swagger-js-codegen.svg?style=flat)](https://codeclimate.com/github/wcandillon/swagger-js-codegen)
 
-This package generates a nodejs or angularjs class from a [swagger specification file](https://github.com/wordnik/swagger-spec). The code is generated using [mustache templates](https://github.com/wcandillon/swagger-js-codegen/tree/master/lib/templates) and is quality checked by [jshint](https://github.com/jshint/jshint/) and beautified by [js-beautify](https://github.com/beautify-web/js-beautify).
+This package generates a nodejs or angularjs class from a [swagger specification file](https://github.com/wordnik/swagger-spec). Also for nodejs generates the models of the objects defined in [swagger specification file](https://github.com/wordnik/swagger-spec).The code is generated using [mustache templates](https://github.com/wcandillon/swagger-js-codegen/tree/master/lib/templates) and is quality checked by [jshint](https://github.com/jshint/jshint/) and beautified by [js-beautify](https://github.com/beautify-web/js-beautify).
 
 ##Installation
 ```bash
@@ -32,6 +32,21 @@ var source = CodeGen.getCustomCode({
         method: fs.readFileSync('my-method.mustache', 'utf-8'),
         request:fs.readFileSync('my-request.mustache', 'utf-8') 
     }
+});
+
+// generate nodejs models
+// set cameCaseFileName to false (default) to create file name in lower case 
+//   e.g. testmodel.js or test-enum.js.
+// otherwise the file name will follow the case convension defined in swagger file.
+
+var nodejsModel = CodeGen.getNodeModelCode( {swagger: swagger, camelCaseFileName : false });})
+
+console.log(nodejsSourceCode);
+console.log(angularjsSourceCode);
+
+for (var model in nodejsModel) {
+    console.log('source file name : '+ nodejsModel[model].fileName);
+    console.log('source code : '+ nodejsModel[model].sourceCode);
 });
 ```
 

--- a/lib/codegen-model.js
+++ b/lib/codegen-model.js
@@ -1,0 +1,362 @@
+'use strict';
+
+var Mustache = require('mustache');
+var _ = require('lodash');
+var fs = require('fs');
+var beautify = require('js-beautify').js_beautify;
+
+/**
+ * camel case format of model name
+ * @param  {[type]} id [description]
+ * @return {[type]}    [description]
+ */
+var typeCamelCase = function(modelName) {
+	var tokens = [];
+
+	modelName.split('-').forEach(function(token, index) {
+		if (token !== '') {
+			if (index === 0) {
+				tokens.push(token[0].toUpperCase() + token.substring(1));
+			} else {
+				tokens.push(token[0].toUpperCase() + token.substring(1));
+			}
+		}
+	});
+	return tokens.join('');
+};
+
+/**
+ * map swagger type to JsDoc types
+ * @param {string} swaggerType
+ * @returns {string}
+ */
+var mapSwaggerTypes = function(swaggerType) {
+	var jsDocType;
+
+	switch (swaggerType.toLowerCase()) {
+		case 'integer':
+			jsDocType = 'number';
+			break;
+		case 'datetime':
+			jsDocType = 'date';
+			break;
+		case 'date-time':
+			jsDocType = 'date';
+			break;
+		default:
+			jsDocType = swaggerType;
+			break;
+	}
+
+	return typeCamelCase(jsDocType);
+};
+
+/**
+ * apply camel case forma
+ * @param  {string} id is value to be processed
+ * @return {string}    modified name
+ */
+var camelCase = function(id) {
+	var tokens = [];
+	id.split('-').forEach(function(token, index) {
+		if (index === 0) {
+			tokens.push(token[0].toLowerCase() + token.substring(1));
+		} else {
+			tokens.push(token[0].toUpperCase() + token.substring(1));
+		}
+	});
+
+	return tokens.join('');
+};
+
+/**
+ * create a var entity
+ * @param  {string} varName  variable nanem
+ * @param  {object} property list of properties from swagger spec that are merged
+ * @return {object}          representing a variable within a generated object
+ */
+var createVar = function(varName, property) {
+	var obj = _.merge({
+		name: camelCase(varName),
+		initValue: 'null',
+		isEnumInLineEnumRef: false
+	}, property);
+
+	if (obj.hasOwnProperty('$ref')) {
+		obj.type = typeCamelCase(obj.$ref);
+	}
+	if (property.format !== undefined) {
+		obj.description = obj.name + ' is defined as a ' + property.format;
+	}
+
+	obj.type = typeCamelCase(mapSwaggerTypes(obj.type));
+
+	return obj;
+};
+
+/**
+ * print js file
+ * @param  {[type]} source [description]
+ * @return {[type]}        [description]
+ */
+var print = function(source) {
+	return beautify(source, {
+		indent_size: 2,
+		max_preserve_newlines: 2
+	});
+};
+
+/**
+ * generate enum data type. This iterates through the enum definitions and creates an enum
+ * @param  {string} property    name of enum we will create
+ * @param  {string} description enum description
+ * @param  {string[]} enumList    list of enum values
+ * @return {[type]}             [description]
+ */
+var generateEnumDataType = function(property, description, enumList) {
+
+	var enumVar = {
+		fileName: property + '-enum',
+		className: typeCamelCase(property + 'Enum'),
+		type: typeCamelCase(property + 'Enum'),
+		name: property,
+		enumValueType: 'string',
+		description: description === undefined ? '' : description,
+		enums: []
+	};
+	enumList.forEach(function(item) {
+		enumVar.enums.push({
+			enumType: item.toUpperCase(),
+			enumValue: item
+		});
+
+	});
+	// mark the last one so that we do not add an
+	enumVar.enums[enumList.length - 1].last = true;
+	//createCode(enumVar.className, print(Mustache.render(templatesEnum, enumVar)));
+	return enumVar;
+};
+
+var isArray = function(varEntry) {
+	var lowcase = varEntry.type.toLowerCase();
+	return lowcase === 'array' || lowcase === 'List';
+};
+
+
+/**
+ * In OO universe there is inheritance ... this is representated as baseClass[<<DerivedClass>>]
+ * This function removes all occurancences of < and >
+ * @param  {[type]} name [description]
+ * @return {[type]}      [description]
+ */
+var trimOOInheritance = function(name) {
+	if (name.indexOf('«') > 0) {
+		var n1 = name.replace('/«/g', '');
+		return n1.replace('/»/g', '');
+	}
+	return name;
+};
+
+
+
+
+/**
+ * create model properties a.k.a attributes
+ * @param  {object[]} swaggerModelProperties model properties within the swagger model
+ * @param {string} className name of class we are creating ..
+ * @return {object}            model properties and any enum specification
+ */
+var createModelProperties = function(swaggerModelProperties, className) {
+	/**
+	 * array of enums that need to be created
+	 * @type {Array}
+	 */
+	var enumsForGeneration = [];
+	/**
+	 * holds the rendered model properties
+	 * @type {Array}
+	 */
+	var modelProperties = [];
+
+	var propertyList = _.keys(swaggerModelProperties);
+
+	propertyList.forEach(function(rawPropertyName) {
+		var property = trimOOInheritance(rawPropertyName);
+		var varEntry = createVar(property, swaggerModelProperties[property]);
+
+
+		// enum processing enums are defined in line
+		if (varEntry.hasOwnProperty('allowableValues')) {
+			if (isArray(varEntry)) {
+				varEntry.array = true;
+			}
+			var allowedEnumVar = generateEnumDataType(className + '-' + typeCamelCase(property),
+				varEntry.description,
+				varEntry.allowableValues.enum);
+
+			varEntry.type = className + allowedEnumVar.type;
+			enumsForGeneration.push(allowedEnumVar);
+
+		} else {
+			// another enum definition -- this is defined in line with the api parameter definition ... 
+			if (varEntry.hasOwnProperty('enum')) {
+				var enumVar = generateEnumDataType(className + '-' + property, varEntry.description, varEntry.enum);
+				enumsForGeneration.push(enumVar);
+				varEntry.type = enumVar.type;
+				varEntry.isEnumInLineEnumRef = true;
+			} else { // look for arrays
+				if (isArray(varEntry)) {
+					varEntry.array = true;
+					varEntry.initValue = '[]';
+
+					if (varEntry.hasOwnProperty('$ref')) { // swagger 2.0 spec
+						varEntry.type = typeCamelCase(varEntry.$ref);
+					} else {
+						// look for array items in swagger 1.2 specification
+						if (varEntry.hasOwnProperty('items')) {
+							var arrayType = varEntry.items.hasOwnProperty('type') ? varEntry.items.type : varEntry.items.$ref;
+
+							varEntry.type = typeCamelCase(mapSwaggerTypes(arrayType));
+						}
+					}
+				}
+
+			}
+		}
+		modelProperties.push(varEntry);
+	});
+
+	// return object contains two lists ... one for enums and another for properties...
+	return {
+		enums: enumsForGeneration,
+		modelProperties: modelProperties
+	};
+};
+
+
+/**
+ * create models defined in swagger api
+ * @param  {string} swagger       model
+ * @param  {string} templateModel mustache template for normal vars
+ * @param  {string} templateEnum  mustache template for enums
+ * @param  {string} camelCaseFileName set to true for file name to be in 'CamelCaseFileName.js' format
+ * @return {{fileName:string,code:string}[]}  where filename is the name of the file the code shoudl be written
+ */
+var createModels = function(swagger, templateModel, templateEnum, camelCaseFileName) {
+	var codeSet = {};
+
+	var swaggerModelList = swagger.swagger === '2.0' ? swagger.definitions : swagger.models;
+	var modelList = _.keys(swaggerModelList);
+
+	modelList.forEach(function(model) {
+
+		// get definition from list 
+		var swagegerModelSpec = swaggerModelList[model];
+
+		var nodeModelProperties = createModelProperties(swagegerModelSpec.properties, model);
+
+		// adjust for namespace ... 
+
+		var nodeModel = {
+			fileName: model,
+			className: trimOOInheritance(model),
+			description: swagegerModelSpec.description,
+			vars: nodeModelProperties.modelProperties
+		};
+
+		// add classes provided we have not added it
+		if (!_.contains(codeSet, nodeModel.className)) {
+			codeSet[nodeModel.className] = {
+				fileName: camelCaseFileName ? typeCamelCase(nodeModel.fileName) : nodeModel.fileName.toLowerCase(),
+				code: print(Mustache.render(templateModel, nodeModel))
+			};
+		}
+
+		// add enums to the list .. this is because models have enums inlined !
+		nodeModelProperties.enums.forEach(function(enumItem) {
+
+			if (!_.contains(codeSet, enumItem.className)) {
+				codeSet[enumItem.className] = {
+					fileName: camelCaseFileName ? typeCamelCase(enumItem.fileName) : enumItem.fileName.toLowerCase(),
+					code: print(Mustache.render(templateEnum, enumItem))
+				};
+			}
+
+		});
+
+	});
+	return codeSet;
+};
+
+
+/**
+ * create a name space aka index.js file that will contain reference to all models referenced by this end point
+ * @param  {string} nameSpace name
+ * @param  {Object} codeSet  is a key value pair represent the models we need to create
+ * @param  {template} template  for render dataset with
+ * @return {Object}     representing the contents we
+ */
+var createNameSpace = function(nameSpace, codeSet, template) {
+	var nameSpaceCodeSet = {
+		nameSpace: nameSpace,
+		fileName: 'index.js',
+		vars: [],
+		nameSpaceCode: null,
+		modelCodeSet: codeSet
+	};
+	var varCounter = 0;
+	for (var varItem in codeSet) {
+		varCounter++;
+		nameSpaceCodeSet.vars.push({
+			name: varItem,
+			fileName: codeSet[varItem].fileName,
+			notLast: true
+		});
+	}
+
+	nameSpaceCodeSet.vars[varCounter - 1].notLast = false;
+
+	nameSpaceCodeSet.nameSpaceCode = print(Mustache.render(template, nameSpaceCodeSet));
+
+	return nameSpaceCodeSet;
+};
+
+/**
+ * create the model code
+ * @param  {Object} opts swagger parameters
+ * @param  {[type]} type type of generation we are doing
+ * @return {array}      of generated code in a key-value pair,
+ *                         where the key is the name of model
+ *                         to be created and value the source code
+ */
+var getModelCode = function(opts, type) {
+
+	var templateModel;
+	var templateEnum;
+	var templateNameSpace;
+	var sourceCode = [];
+
+	if (type === 'custom') {
+		if (!_.isObject(opts.template) || !_.isString(opts.template.class) || !_.isString(opts.template.method) || !_.isString(opts.template.request)) {
+			throw new Error('Unprovided custom template. Please use the following template: template: { class: "...", method: "...", request: "..." }');
+		}
+		templateModel = opts.template.modelClass;
+		templateEnum = opts.template.modelEnum;
+		templateNameSpace = opts.template.nameSpace;
+	} else {
+		templateModel = fs.readFileSync(__dirname + '/../templates/' + type + '-model-class.mustache', 'utf-8');
+		templateEnum = fs.readFileSync(__dirname + '/../templates/' + type + '-enum-class.mustache', 'utf-8');
+		templateNameSpace = fs.readFileSync(__dirname + '/../templates/' + type + '-model-namespace.mustache', 'utf-8');
+	}
+
+	sourceCode = createModels(opts.swagger, templateModel, templateEnum,
+		opts.camelCaseFileName === undefined ? false : opts.camelCaseFileName);
+
+	return createNameSpace(opts.nameSpace, sourceCode, templateNameSpace);
+};
+
+exports.CodeGenModel = {
+	getCodeGen: function(opts, type) {
+		return getModelCode(opts, type);
+	}
+};

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -6,194 +6,282 @@ var beautify = require('js-beautify').js_beautify;
 var lint = require('jshint').JSHINT;
 var _ = require('lodash');
 
+var CodeGenModel = require('./codegen-model.js').CodeGenModel;
+
 var camelCase = function(id) {
-    var tokens = [];
-    id.split('-').forEach(function(token, index){
-        if(index === 0) {
-            tokens.push(token[0].toLowerCase() + token.substring(1));
-        } else {
-            tokens.push(token[0].toUpperCase() + token.substring(1));
-        }
-    });
-    return tokens.join('');
+	var tokens = [];
+	id.split('-').forEach(function(token, index) {
+		if (index === 0) {
+			tokens.push(token[0].toLowerCase() + token.substring(1));
+		} else {
+			tokens.push(token[0].toUpperCase() + token.substring(1));
+		}
+	});
+	return tokens.join('');
 };
 
-var getPathToMethodName = function(m, path){
-    var segments = path.split('/').slice(1);
-    segments = _.transform(segments, function(result, segment){
-        if(segment[0] === '{' && segment[segment.length - 1] === '}') {
-            segment = 'by' + segment[1].toUpperCase() + segment.substring(2, segment.length - 1);
-        }
-        result.push(segment);
-    });
-    var result = camelCase(segments.join('-'));
-    return m.toLowerCase() + result[0].toUpperCase() + result.substring(1);
+/**
+ * we need to define content-type header entry otherwise
+ * @param defaultContentType
+ * @param opContentType
+ * @returns {string}
+ */
+var mergeContentTypes = function(defaultContentType, opContentType) {
+	var contentTypes = '';
+	// serialize default
+	defaultContentType.forEach(function(cType) {
+		if (contentTypes.indexOf(cType) === -1) {
+			contentTypes = contentTypes.length > 0 ? ';' + cType : cType;
+		}
+	});
+
+	// merge in operation
+	opContentType.forEach(function(cType) {
+		if (contentTypes.indexOf(cType) === -1) {
+			contentTypes = contentTypes.length > 0 ? ';' + cType : cType;
+		}
+	});
+
+	return contentTypes;
 };
 
-var getViewForSwagger2 = function(opts, type){
-    var swagger = opts.swagger;
-    var authorizedMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'COPY', 'HEAD', 'OPTIONS', 'LINK', 'UNLIK', 'PURGE', 'LOCK', 'UNLOCK', 'PROPFIND'];
-    var data = {
-        isNode: type === 'node',
-        description: swagger.info.description,
-        isSecure: swagger.securityDefinitions !== undefined,
-        moduleName: opts.moduleName,
-        className: opts.className,
-        domain: (swagger.schemes && swagger.schemes.length > 0 && swagger.host && swagger.basePath) ? swagger.schemes[0] + '://' + swagger.host + swagger.basePath : '',
-        methods: []
-    };
-
-    _.forEach(swagger.paths, function(api, path){
-        var globalParams = [];
-        _.forEach(api, function(op, m){
-            if(m.toLowerCase() === 'parameters') {
-                globalParams = op;
-            }
-        });
-        _.forEach(api, function(op, m){
-            if(authorizedMethods.indexOf(m.toUpperCase()) === -1) {
-                return;
-            }
-            var method = {
-                path: path,
-                className: opts.className,
-                methodName: op['x-swagger-js-method-name'] ? op['x-swagger-js-method-name'] : (op.operationId ? op.operationId : getPathToMethodName(m, path)),
-                method: m.toUpperCase(),
-                isGET: m.toUpperCase() === 'GET',
-                summary: op.description,
-                isSecure: op.security !== undefined,
-                parameters: []
-            };
-            var params = [];
-            if(_.isArray(op.parameters)) {
-                params = op.parameters;
-            }
-            params = params.concat(globalParams);
-            _.chain(params).forEach(function(parameter) {
-                if (_.isString(parameter.$ref)) {
-                    var segments = parameter.$ref.split('/');
-                    parameter = swagger.parameters[segments.length === 1 ? segments[0] : segments[2] ];
-                }
-                parameter.camelCaseName = camelCase(parameter.name);
-                if(parameter.enum && parameter.enum.length === 1) {
-                    parameter.isSingleton = true;
-                    parameter.singleton = parameter.enum[0];
-                }
-                if(parameter.in === 'body'){
-                    parameter.isBodyParameter = true;
-                } else if(parameter.in === 'path'){
-                    parameter.isPathParameter = true;
-                } else if(parameter.in === 'query'){
-                    if(parameter.pattern){
-                        parameter.isPatternType = true;
-                    }
-                    parameter.isQueryParameter = true;
-                } else if(parameter.in === 'header'){
-                    parameter.isHeaderParameter = true;
-                } else if(parameter.in === 'formData'){
-                    parameter.isFormParameter = true;
-                }
-                method.parameters.push(parameter);
-            });
-            data.methods.push(method);
-        });
-    });
-    return data;
+var getPathToMethodName = function(m, path) {
+	var segments = path.split('/').slice(1);
+	segments = _.transform(segments, function(result, segment) {
+		if (segment[0] === '{' && segment[segment.length - 1] === '}') {
+			segment = 'by' + segment[1].toUpperCase() + segment.substring(2, segment.length - 1);
+		}
+		result.push(segment);
+	});
+	var result = camelCase(segments.join('-'));
+	return m.toLowerCase() + result[0].toUpperCase() + result.substring(1);
 };
 
-var getViewForSwagger1 = function(opts, type){
-    var swagger = opts.swagger;
-    var data = {
-        isNode: type === 'node',
-        description: swagger.description,
-        moduleName: opts.moduleName,
-        className: opts.className,
-        domain: swagger.basePath ? swagger.basePath : '',
-        methods: []
-    };
-    swagger.apis.forEach(function(api){
-        api.operations.forEach(function(op){
-            var method = {
-                path: api.path,
-                className: opts.className,
-                methodName: op.nickname,
-                method: op.method,
-                isGET: op.method === 'GET',
-                summary: op.summary,
-                parameters: op.parameters
-            };
-            op.parameters = op.parameters ? op.parameters : [];
-            op.parameters.forEach(function(parameter) {
-                parameter.camelCaseName = camelCase(parameter.name);
-                if(parameter.enum && parameter.enum.length === 1) {
-                    parameter.isSingleton = true;
-                    parameter.singleton = parameter.enum[0];
-                }
-                if(parameter.paramType === 'body'){
-                    parameter.isBodyParameter = true;
-                } else if(parameter.paramType === 'path'){
-                    parameter.isPathParameter = true;
-                } else if(parameter.paramType === 'query'){
-                    if(parameter.pattern){
-                        parameter.isPatternType = true;
-                    }
-                    parameter.isQueryParameter = true;
-                } else if(parameter.paramType === 'header'){
-                    parameter.isHeaderParameter = true;
-                } else if(parameter.paramType === 'form'){
-                    parameter.isFormParameter = true;
-                }
-            });
-            data.methods.push(method);
-        });
-    });
-    return data;
+/**
+ * extract response model from specification - is supports on swagger v1.2
+ * @param  {object} op [description]
+ * @return {string}    name of type ..
+ */
+var getResponseModelV2 = function(op) {
+	var responseModel = 'object'; // set default ..
+
+	if (op.type !== undefined) {
+		if (op.type.toLowerCase() === 'array' || op.type.toLowerCase() === 'list') {
+			if (op.items !== null && op.items.hasOwnProperty('$ref')) {
+				responseModel = op.items.$ref + '[]';
+			}
+		} else {
+			responseModel = op.type;
+		}
+	}
+
+	return responseModel;
+};
+
+var getViewForSwagger2 = function(opts, type) {
+	var swagger = opts.swagger;
+	var authorizedMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'COPY', 'HEAD', 'OPTIONS', 'LINK', 'UNLIK', 'PURGE', 'LOCK', 'UNLOCK', 'PROPFIND'];
+	var defaultContentType = [];
+
+	var data = {
+		isNode: type === 'node',
+		description: swagger.info.description,
+		isSecure: swagger.securityDefinitions !== undefined,
+		moduleName: opts.moduleName,
+		className: opts.className,
+		domain: (swagger.schemes && swagger.schemes.length > 0 && swagger.host && swagger.basePath) ? swagger.schemes[0] + '://' + swagger.host + swagger.basePath : '',
+		methods: []
+	};
+	defaultContentType = swagger.consumes || [];
+
+	_.forEach(swagger.paths, function(api, path) {
+		var globalParams = [];
+		_.forEach(api, function(op, m) {
+			if (m.toLowerCase() === 'parameters') {
+				globalParams = op;
+			}
+		});
+		_.forEach(api, function(op, m) {
+			if (authorizedMethods.indexOf(m.toUpperCase()) === -1) {
+				return;
+			}
+			var method = {
+				path: path,
+				className: opts.className,
+				methodName: op['x-swagger-js-method-name'] ? op['x-swagger-js-method-name'] : (op.operationId ? op.operationId : getPathToMethodName(m, path)),
+				method: m.toUpperCase(),
+				isGET: m.toUpperCase() === 'GET',
+				summary: op.description,
+				isSecure: op.security !== undefined,
+				parameters: []
+			};
+			method.responseModel = getResponseModelV2(op);
+			method.contentTypes = mergeContentTypes(defaultContentType, op.consumes || []);
+
+			var params = [];
+			if (_.isArray(op.parameters)) {
+				params = op.parameters;
+			}
+			params = params.concat(globalParams);
+			_.chain(params).forEach(function(parameter) {
+				if (_.isString(parameter.$ref)) {
+					var segments = parameter.$ref.split('/');
+					parameter = swagger.parameters[segments.length === 1 ? segments[0] : segments[2]];
+				}
+				parameter.camelCaseName = camelCase(parameter.name);
+				if (parameter.enum && parameter.enum.length === 1) {
+					parameter.isSingleton = true;
+					parameter.singleton = parameter.enum[0];
+				}
+				if (parameter.in === 'body') {
+					parameter.isBodyParameter = true;
+				} else if (parameter.in === 'path') {
+					parameter.isPathParameter = true;
+				} else if (parameter.in === 'query') {
+					if (parameter.pattern) {
+						parameter.isPatternType = true;
+					}
+					parameter.isQueryParameter = true;
+				} else if (parameter.in === 'header') {
+					parameter.isHeaderParameter = true;
+				} else if (parameter.in === 'formData') {
+					parameter.isFormParameter = true;
+				}
+				method.parameters.push(parameter);
+			});
+			data.methods.push(method);
+		});
+	});
+	return data;
+};
+/**
+ * extract response model from specification - is supports on swagger v1.2
+ * @param  {object} op [description]
+ * @return {string}    name of type ..
+ */
+var getResponseModelV1 = function(op) {
+	var responseModel = 'object'; // set default ..
+
+	if (op.type !== undefined) {
+		if (op.type.toLowerCase() === 'array' || op.type.toLowerCase() === 'list') {
+			if (op.items !== null && op.items.hasOwnProperty('$ref')) {
+				responseModel = op.items.$ref + '[]';
+			}
+		} else {
+			responseModel = op.type;
+		}
+	}
+
+	return responseModel;
+};
+
+var getViewForSwagger1 = function(opts, type) {
+	var swagger = opts.swagger;
+	var defaultContentType = [];
+	var data = {
+		isNode: type === 'node',
+		description: swagger.description,
+		moduleName: opts.moduleName,
+		className: opts.className,
+		domain: swagger.basePath ? swagger.basePath : '',
+		methods: []
+	};
+	defaultContentType = swagger.consumes || [];
+	swagger.apis.forEach(function(api) {
+		api.operations.forEach(function(op) {
+			var method = {
+				path: api.path,
+				className: opts.className,
+				methodName: op.nickname,
+				method: op.method,
+				isGET: op.method === 'GET',
+				summary: op.summary,
+				parameters: op.parameters
+			};
+			method.responseModel = getResponseModelV1(op);
+			method.contentTypes = mergeContentTypes(defaultContentType, op.consumes || []);
+			op.parameters = op.parameters ? op.parameters : [];
+			op.parameters.forEach(function(parameter) {
+				parameter.camelCaseName = camelCase(parameter.name);
+				if (parameter.enum && parameter.enum.length === 1) {
+					parameter.isSingleton = true;
+					parameter.singleton = parameter.enum[0];
+				}
+				if (parameter.paramType === 'body') {
+					parameter.isBodyParameter = true;
+				} else if (parameter.paramType === 'path') {
+					parameter.isPathParameter = true;
+				} else if (parameter.paramType === 'query') {
+					if (parameter.pattern) {
+						parameter.isPatternType = true;
+					}
+					parameter.isQueryParameter = true;
+				} else if (parameter.paramType === 'header') {
+					parameter.isHeaderParameter = true;
+				} else if (parameter.paramType === 'form') {
+					parameter.isFormParameter = true;
+				}
+			});
+			data.methods.push(method);
+		});
+	});
+	return data;
 };
 
 var getCode = function(opts, type) {
-    var tpl, method, request;
-    // For Swagger Specification version 2.0 value of field 'swagger' must be a string '2.0'
-    var data = opts.swagger.swagger === '2.0' ? getViewForSwagger2(opts, type) : getViewForSwagger1(opts, type);
-    if(type === 'custom') {
-        if(!_.isObject(opts.template) || !_.isString(opts.template.class)  || !_.isString(opts.template.method) || !_.isString(opts.template.request)) {
-            throw new Error('Unprovided custom template. Please use the following template: template: { class: "...", method: "...", request: "..." }');
-        }
-        tpl = opts.template.class;
-        method = opts.template.method;
-        request = opts.template.request;
-    } else {
-        tpl = fs.readFileSync(__dirname + '/../templates/' + type + '-class.mustache', 'utf-8');
-        method = fs.readFileSync(__dirname + '/../templates/method.mustache', 'utf-8');
-        request = fs.readFileSync(__dirname + '/../templates/' + type + '-request.mustache', 'utf-8');
-    }
-    var source = Mustache.render(tpl, data, {
-        method: method,
-        request: request
-    });
-    lint(source, {
-        node: type === 'node' || type === 'custom',
-        browser: type === 'angular' || type === 'custom',
-        undef: true,
-        strict: true,
-        trailing: true,
-        smarttabs: true
-    });
-    lint.errors.forEach(function(error){
-        if(error.code[0] === 'E') {
-            throw new Error(lint.errors[0].reason + ' in ' + lint.errors[0].evidence);
-        }
-    });
-    return beautify(source, { indent_size: 4, max_preserve_newlines: 2 });
+	var tpl, method, request;
+	// For Swagger Specification version 2.0 value of field 'swagger' must be a string '2.0'
+	var data = opts.swagger.swagger === '2.0' ? getViewForSwagger2(opts, type) : getViewForSwagger1(opts, type);
+	if (type === 'custom') {
+		if (!_.isObject(opts.template) || !_.isString(opts.template.class) || !_.isString(opts.template.method) || !_.isString(opts.template.request)) {
+			throw new Error('Unprovided custom template. Please use the following template: template: { class: "...", method: "...", request: "..." }');
+		}
+		tpl = opts.template.class;
+		method = opts.template.method;
+		request = opts.template.request;
+	} else {
+		tpl = fs.readFileSync(__dirname + '/../templates/' + type + '-class.mustache', 'utf-8');
+		method = fs.readFileSync(__dirname + '/../templates/method.mustache', 'utf-8');
+		request = fs.readFileSync(__dirname + '/../templates/' + type + '-request.mustache', 'utf-8');
+	}
+	var source = Mustache.render(tpl, data, {
+		method: method,
+		request: request
+	});
+	lint(source, {
+		node: type === 'node' || type === 'custom',
+		browser: type === 'angular' || type === 'custom',
+		undef: true,
+		strict: true,
+		trailing: true,
+		smarttabs: true
+	});
+	lint.errors.forEach(function(error) {
+		if (error.code[0] === 'E') {
+			throw new Error(lint.errors[0].reason + ' in ' + lint.errors[0].evidence);
+		}
+	});
+	return beautify(source, {
+		indent_size: 4,
+		max_preserve_newlines: 2
+	});
 };
 
+
 exports.CodeGen = {
-    getAngularCode: function(opts){
-        return getCode(opts, 'angular');
-    },
-    getNodeCode: function(opts){
-        return getCode(opts, 'node');
-    },
-    getCustomCode: function(opts){
-        return getCode(opts, 'custom');
-    }
+	getAngularCode: function(opts) {
+		return getCode(opts, 'angular');
+	},
+	getNodeCode: function(opts) {
+		return getCode(opts, 'node');
+	},
+	getCustomCode: function(opts) {
+		return getCode(opts, 'custom');
+	},
+	getNodeModelCode: function(opts) {
+		return CodeGenModel.getCodeGen(opts, 'node');
+	},
+	getNodeCustomModelCode: function(opts) {
+		return CodeGenModel.getCodeGen(opts, 'custom');
+	}
 };

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -2,9 +2,12 @@
  * {{&summary}}
  * @method
  * @name {{&className}}#{{&methodName}}
+ * @param {object} parameters 
 {{#parameters}}
-{{^isSingleton}} * @param {{=<% %>=}}{<%&type%>}<%={{ }}=%> {{&camelCaseName}} - {{&description}}{{/isSingleton}}
+{{^isSingleton}} * @param {{=<% %>=}}{<%&type%>}<%={{ }}=%> [parameters.{{&camelCaseName}}] - {{&description}}{{/isSingleton}}
 {{/parameters}}
+* @param {object} [parameters.$queryParameters] other parameters to be passed in he query string
+ * @return {external:Promise} On success the promise will be resolved with  {response:{Response}, body: {{=<% %>=}}{<%&responseModel%>}<%={{ }}=%>}
  * 
  */
  {{&className}}.prototype.{{&methodName}} = function(parameters){
@@ -14,8 +17,9 @@
     var deferred = {{#isNode}}Q{{/isNode}}{{^isNode}}$q{{/isNode}}.defer();
     
     var domain = this.domain;
-    var path = '{{&path}}';
     
+    var path = '{{&path}}';
+
     var body;
     var queryParameters = {};
     var headers = {};
@@ -30,6 +34,8 @@
             headers['Authorization'] = 'Bearer ' + this.token.value;
         }
     {{/isSecure}}
+    
+    {{#contentTypes}}headers['content-type']='{{&contentTypes}}';{{/contentTypes}}
 
     {{#parameters}}
        

--- a/templates/node-class.mustache
+++ b/templates/node-class.mustache
@@ -1,10 +1,19 @@
 /*jshint -W069 */
+'use strict';
+
+/**
+ * A promise object provided by the q promise library
+ * @external Promise
+ * @see {@link https://github.com/kriskowal/q/wiki/API-Reference}
+ */
+
 /**
  * {{&description}}
  * @class {{&className}}
  * @param {(string|object)} [domainOrOptions] - The project domain or options object. If object, see the object's optional properties.
  * @param {string} [domainOrOptions.domain] - The project domain
  * @param {object} [domainOrOptions.token] - auth token - object with value property and optional headerOrQueryName and isQuery properties
+ * @param {integer} [domainOrOptions.timeout] - timeout period for queries defaults to 10 seconds
  */
 var {{&className}} = (function(){
     'use strict';
@@ -14,6 +23,7 @@ var {{&className}} = (function(){
 
     function {{&className}}(options){
         var domain = (typeof options === 'object') ? options.domain : options;
+
         this.domain = domain ? domain : '{{&domain}}';
         if(this.domain.length === 0) {
             throw new Error('Domain parameter must be specified as a string.');
@@ -21,6 +31,9 @@ var {{&className}} = (function(){
         {{#isSecure}}
             this.token = (typeof options === 'object') ? (options.token ? options.token : {}) : {};
         {{/isSecure}}
+
+        this.timeout = (typeof options === 'object') ? options.timeout : undefined;
+
     }
 
     {{#isSecure}}

--- a/templates/node-enum-class.mustache
+++ b/templates/node-enum-class.mustache
@@ -1,0 +1,17 @@
+/*jshint -W069 */
+'use strict';
+
+
+/**
+ * {{className}} {{description}}
+ * @readonly
+ * @enum { {{enumValueType}} } 
+ * @swagger enum 
+ */
+exports.{{className}} = {
+		{{#enums}}
+			{{enumType}}:'{{enumValue}}' {{^last}}, {{/last}}
+		{{/enums}}
+	};
+
+

--- a/templates/node-model-class.mustache
+++ b/templates/node-model-class.mustache
@@ -1,0 +1,18 @@
+/*jshint -W069 */
+'use strict';
+
+/**
+ * {{description}}
+ * @class {{className}}
+ * @swagger model
+ */
+exports.{{className}} = function() {
+ 		{{#vars}}
+			/**
+			 * {{description}}
+			 * @type { {{type}} {{#array}}[]{{/array}} }
+			 */
+			this.{{name}}={{initValue}} ;
+
+ 		{{/vars}}
+};

--- a/templates/node-model-namespace.mustache
+++ b/templates/node-model-namespace.mustache
@@ -1,0 +1,13 @@
+/*jshint -W069 */
+'use strict';
+
+/**
+ * {{description}}
+ * @class {{nameSpace}}
+ * @swagger namespace
+ */
+exports.{{nameSpace}} = {
+ 		{{#vars}}
+			{{name}}:require('./{{fileName}}.js').{{name}}{{#notLast}},{{/notLast}}
+ 		{{/vars}}
+};

--- a/templates/node-request.mustache
+++ b/templates/node-request.mustache
@@ -6,6 +6,11 @@ var req = {
     body: body,
     rejectUnauthorized: false
 };
+
+if (this.timeout!==undefined) {
+    req.timeout = this.timeout;
+}
+
 if(Object.keys(form).length > 0) {
     req.form = form;
 }

--- a/tests/generation.js
+++ b/tests/generation.js
@@ -5,7 +5,7 @@ var vows = require('vows');
 var fs = require('fs');
 var ffs = require('final-fs');
 
-var CodeGen = require('../lib/codegen').CodeGen;
+var CodeGen = require('../lib/codegen.js').CodeGen;
 
 var batch = {};
 var list = ffs.readdirSync('tests/apis');

--- a/tests/model-generation.js
+++ b/tests/model-generation.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var vows = require('vows');
+var assert = require('assert');
+var fs = require('fs');
+//var events = require('events');
+
+var CodeGen = require('../lib/codegen.js').CodeGen;
+
+vows.describe('Test Generated Models').addBatch({
+    'Test model generation for models/model-test.json': {
+        topic: function() {
+            var swagger = JSON.parse(fs.readFileSync('tests/models/model-test.json', 'UTF-8'));
+
+            var nameSpaceCode = CodeGen.getNodeModelCode({
+                nameSpace: 'proj',
+                swagger: swagger
+            });
+            var srcCode = nameSpaceCode.modelCodeSet;
+            // pretend code generation ... 
+            // the indented generate file structure is 
+            
+            var mockIndex = {};
+
+            mockIndex[nameSpaceCode.nameSpace]={};
+
+            // get out each defined model
+            for (var item in srcCode) {
+                /*jshint evil:true*/
+                mockIndex.proj[item] = eval(srcCode[item].code);
+            }
+
+            return mockIndex;
+        },
+        'should have an object called proj (pretend nameSpace)':function(genModels) {
+            assert.equal(genModels.proj!==null,true);
+        },
+        'should have an object with some proporties': function(genModels) {
+            var propCounter = 0;
+            for (var propName in genModels.proj) {
+                if (genModels.proj.hasOwnProperty(propName)) {
+                    ++propCounter;
+                }
+            }
+            assert.equal(propCounter > 0, true);
+        },
+        'genModels should have an enum called ProjTestNameEnum ': function(genModels) {
+            assert.equal(genModels.proj.TestNameEnum !== null, true);
+        },
+        'ProjTestNameEnum should have a property called ProjTestNameEnum.CONNECTION with value "connection"': function(genModels) {
+            assert.equal(genModels.proj.TestNameEnum.CONNECTION === 'connection', true);
+        },
+        'genModels should have an object called ProjSubscription ': function(genModels) {
+            assert.equal(genModels.proj.Subscription !== null, true);
+        },
+        'Should be able to create an instance of ProjSubscription called sub': {
+            topic: function(genModels) {
+                var sub = new genModels.proj.Subscription();
+                assert.equal(sub !== null, true);
+                return sub;
+            },
+            'sub should have a property called subscriptionAddOns': function(sub) {
+                assert.equal(sub.subscriptionAddOns !== null, true);
+            },
+            'sub.subscriptionAddOns should be of type array': function(sub) {
+                assert.equal(typeof(sub.subscriptionAddOns) === typeof([]), true);
+            }
+        }
+    }
+}).export(module);

--- a/tests/models/model-test.json
+++ b/tests/models/model-test.json
@@ -1,0 +1,272 @@
+{
+	"apiVersion": "1.0",
+	"swaggerVersion": "1.2",
+	"basePath": "http://api.xbrl.io",
+	"resourcePath": "/project",
+	"produces": [
+		"application/json"
+	],
+	"apis": [],
+	"models": {
+		"BreakdownTaskHeader": {
+			"id": "BreakdownTaskHeader",
+			"description": "",
+			"extends": "",
+			"properties": {
+					"resourceArrivalActual": {
+						"$ref": "date-time"
+					},
+					"resourceArrivalActual": {
+						"$ref": "Subscription"
+					},
+					"breakdownSequenceNumber": {
+						"type": "integer",
+						"format": "int32"
+					}
+				}
+			},
+		"CoveredVehicleDetails": {
+			"id": "CoveredVehicleDetails",
+			"description": "",
+			"extends": "",
+			"properties": {
+				"address": {
+					"$ref": "Address"
+				},
+				"id": {
+					"type": "integer",
+					"format": "int64"
+				},
+				"type": {
+					"type": "string"
+				},
+				"options": {
+					"$ref": "VehicleOptions"
+				},
+				"model": {
+					"type": "string"
+				},
+				"startDate": {
+					"$ref": "date-time"
+				},
+				"endDate": {
+					"$ref": "date-time"
+				},
+				"dealer": {
+					"$ref": "Organisation"
+				},
+				"regNum": {
+					"type": "string"
+				},
+				"prevRegNum": {
+					"type": "string"
+				},
+				"make": {
+					"type": "string"
+				},
+				"colour": {
+					"type": "string"
+				},
+				"modelYear": {
+					"type": "string"
+				},
+				"regDate": {
+					"$ref": "date-time"
+				},
+				"oldVehicle": {
+					"type": "string"
+				},
+				"vin": {
+					"type": "string"
+				},
+				"axleNumber": {
+					"type": "string"
+				},
+				"maintenanceAgent": {
+					"$ref": "Organisation"
+				},
+				"additionalDetail": {
+					"type": "string"
+				},
+				"fleetMembershipNo": {
+					"type": "string"
+				},
+				"vehicleValidation": {
+					"type": "string"
+				}
+			}
+		},
+			"Subscription": {
+				"id": "Subscription",
+				"description": "A subscription",
+				"required": [
+					"uuid",
+					"href",
+					"state",
+					"plan",
+					"unitAmountInCents",
+					"currency",
+					"quantity",
+					"activatedAt",
+					"subscriptionAddOns"
+				],
+				"properties": {
+					"href": {
+						"type": "string",
+						"description": "The URL relative to the API endpoint to fetch, modify or terminate the subscription"
+					},
+					"uuid": {
+						"type": "string",
+						"description": "The subscription UUID"
+					},
+					"state": {
+						"type": "string",
+						"description": "The subscription state"
+					},
+					"plan": {
+						"type": "Plan",
+						"description": "The subscription plan"
+					},
+					"unitAmountInCents": {
+						"type": "integer",
+						"description": "The subscription unit amount in cents"
+					},
+					"quantity": {
+						"type": "integer",
+						"description": "The subscription quantity"
+					},
+					"currency": {
+						"type": "string",
+						"description": "The subscription currency"
+					},
+					"activatedAt": {
+						"type": "date-time",
+						"description": "The subscription activation date"
+					},
+					"canceledAt": {
+						"type": "date-time",
+						"description": "The subscription cancellation date"
+					},
+					"expiresAt": {
+						"type": "date-time",
+						"description": "The subscription expiration date"
+					},
+					"currentPeriodStartedAt": {
+						"type": "date-time",
+						"description": "The subscription current period starting date"
+					},
+					"currentPeriodEndsAt": {
+						"type": "date-time",
+						"description": "The subscription current period ending date"
+					},
+					"trialStartedAt": {
+						"type": "date-time",
+						"description": "The subscription trial period starting date"
+					},
+					"trialEndsAt": {
+						"type": "date-time",
+						"description": "The subscription trial period ending date"
+					},
+					"taxInCents": {
+						"type": "integer",
+						"description": "The subscription tax amount in cents"
+					},
+					"taxType": {
+						"type": "string",
+						"description": "The subscription type of tax, e.g.: vat or usst"
+					},
+					"taxRate": {
+						"type": "float",
+						"description": "The subscription tax rate"
+					},
+					"poNumber": {
+						"type": "string",
+						"description": "The subscription PO number"
+					},
+					"netTerms": {
+						"type": "integer",
+						"description": "The subscription net terms in days"
+					},
+					"subscriptionAddOns": {
+						"type": "array",
+						"items": {
+							"$ref": "Addon"
+						},
+						"description": "The subscription addons"
+					},
+					"pendingSubscription": {
+						"type": "Subscription",
+						"description": "Nested information about a pending subscription change at renewal"
+					}
+				}
+			},
+			"Success": {
+				"id": "Success",
+				"description": "Default success response",
+				"required": ["success"],
+				"properties": {
+					"success": {
+						"type": "boolean",
+						"enum": [
+							"true"
+						]
+					}
+				}
+			},
+			"Error": {
+				"id": "Error",
+				"description": "Error information",
+				"required": [
+					"code",
+					"message",
+					"description"
+				],
+				"properties": {
+					"code": {
+						"type": "string",
+						"description": "The XQuery error code of the error"
+					},
+					"message": {
+						"type": "string",
+						"description": "A formatted string which contain the error code (always) and the module name, line and column-number and error description (when available)"
+					},
+					"description": {
+						"type": "string",
+						"description": "The error description"
+					},
+					"module": {
+						"type": "string",
+						"description": "The error module"
+					},
+					"line-number": {
+						"type": "string",
+						"description": "The error line number"
+					},
+					"column-number": {
+						"type": "string",
+						"description": "The error column number"
+					}
+				}
+			},
+			"Test": {
+				"id": "Test",
+				"description": "Credentials test result",
+				"required": ["name", "success", "message"],
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "The name of the test",
+						"enum": ["connection", "writeable"]
+					},
+					"success": {
+						"type": "boolean",
+						"description": "Whether the test passed or not"
+					},
+					"message": {
+						"type": "string",
+						"description": "A description of the test result"
+					}
+				}
+			}
+		}
+	}

--- a/tests/node-api.js
+++ b/tests/node-api.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 var fs = require('fs');
 var events = require('events');
 
-var CodeGen = require('../lib/codegen').CodeGen;
+var CodeGen = require('../lib/codegen.js').CodeGen;
 
 vows.describe('Test Generated API').addBatch({
     'Test Generated code for the 28.io Auth API': {

--- a/tests/node-protected.js
+++ b/tests/node-protected.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 var fs = require('fs');
 var events = require('events');
 
-var CodeGen = require('../lib/codegen').CodeGen;
+var CodeGen = require('../lib/codegen.js').CodeGen;
 
 function createAPI (options) {
     var swagger = JSON.parse(fs.readFileSync('tests/apis/protected.json', 'UTF-8'));


### PR DESCRIPTION
1 : generated requests for node now
  a : include support for timeout
  b : additional jsdoc entries to help in development 
  c : extract from swagger spec the supported contentType and inclusion those to the request
2 : generate models defined in swagger doc. Unfortunately this only supports swagger 1.2 specification