### PR TITLE
Add option to support ES6

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -172,6 +172,11 @@ var getCode = function(opts, type) {
         method = fs.readFileSync(__dirname + '/../templates/method.mustache', 'utf-8');
         request = fs.readFileSync(__dirname + '/../templates/' + type + '-request.mustache', 'utf-8');
     }
+
+    if (opts.mustache) {
+        _.assign(data, opts.mustache);
+    }
+
     var source = Mustache.render(tpl, data, {
         method: method,
         request: request

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -176,14 +176,18 @@ var getCode = function(opts, type) {
         method: method,
         request: request
     });
-    lint(source, {
+    var lintOptions = {
         node: type === 'node' || type === 'custom',
         browser: type === 'angular' || type === 'custom',
         undef: true,
         strict: true,
         trailing: true,
         smarttabs: true
-    });
+    };
+    if (opts.esnext) {
+        lintOptions.esnext = true;
+    }
+    lint(source, lintOptions);
     lint.errors.forEach(function(error){
         if(error.code[0] === 'E') {
             throw new Error(lint.errors[0].reason + ' in ' + lint.errors[0].evidence);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "js-beautify": "~1.5.1",
     "jshint": "~2.5.1",
     "lodash": "^2.4.1",
-    "mustache": "~0.8.2"
+    "mustache": "^2.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.4",


### PR DESCRIPTION
Minimal change that allows swagger-js-codegen to work with ES6 code in the given templates.