### PR TITLE
Added stripPathPrefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ In addition to the common options listed below, `getCustomCode()` *requires* a `
     description: Your AngularJS module name
   className:
     type: string
+  stripPathPrefix:
+    type: string
+    description: removes a prefix from the API path from being used as method names.
   esnext:
     type: boolean
     description: passed through to jslint

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -21,15 +21,25 @@ var camelCase = function(id) {
     return tokens.join('');
 };
 
-var getPathToMethodName = function(m, path){
+var getPathToMethodName = function(m, path, opts){
     if(path === '/' || path === '') {
         return m;
     }
-    
+
     // clean url path for requests ending with '/'
     var cleanPath = path;
+    var stripPrefix = opts.stripPathPrefix;
     if( cleanPath.indexOf('/', cleanPath.length - 1) !== -1 ) {
         cleanPath = cleanPath.substring(0, cleanPath.length - 1);
+    }
+
+    if(stripPrefix) {
+        var stripPrefixLength = stripPrefix.length;
+        if (cleanPath.indexOf(stripPrefix) === 0) {
+            if (cleanPath.length > stripPrefixLength) {
+                cleanPath = cleanPath.substr(stripPrefixLength);
+            }
+        }
     }
 
     var segments = cleanPath.split('/').slice(1);
@@ -74,7 +84,7 @@ var getViewForSwagger2 = function(opts, type){
             var method = {
                 path: path,
                 className: opts.className,
-                methodName: op['x-swagger-js-method-name'] ? op['x-swagger-js-method-name'] : (op.operationId ? op.operationId : getPathToMethodName(m, path)),
+                methodName: op['x-swagger-js-method-name'] ? op['x-swagger-js-method-name'] : (op.operationId ? op.operationId : getPathToMethodName(m, path, opts)),
                 method: m.toUpperCase(),
                 isGET: m.toUpperCase() === 'GET',
                 summary: op.description,


### PR DESCRIPTION
This allows you to for remove an API path prefix from being used in your method names. 
For instance if your endpoint is `/api/v1/list/users`
Pre-PR would result in : `getApiV1ListUsers()`
Unless you manually named each route (annoying) 

Now you can set `stripPathPrefix` to a value of `/api/v1` and your method name would be:
`getListUsers()`
And no need to manually name every route! :) 