### PR TITLE
Adding generation of TypeScript definitions for the angular code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ eg: https://cloud.google.com/appengine/docs/go/requests#Go_Request_headers
 ```
 
 
-## Generating TypeScript definition files
+## Generating TypeScript definition files --- EXPERIMENTAL
 
 For both the node and the angular code, TypeScript definition files (`.d.ts`) can be generated that define the interface of the module.
 This includes the data types for the parameters and results of all methods. This allows static type checking of your
@@ -263,7 +263,7 @@ var tsdCode = CodeGen.getAngularTypeScriptDefinition({ className: 'Test', swagge
 console.log(tsdCode);
 ```
 
-
+Note that this feature is experimental and has not seen many testing yet.
 
 
 ## Grunt & Gulp task

--- a/README.md
+++ b/README.md
@@ -246,6 +246,26 @@ eg: https://cloud.google.com/appengine/docs/go/requests#Go_Request_headers
 ```
 
 
+## Generating TypeScript definition files
+
+For the angular code, TypeScript definition files (`.d.ts`) can be generated that define the interface of the module.
+This includes the data types for the parameters and results of all methods. This allows static type checking of your
+API calls.
+
+TypeScript generation works similar to Javascript:
+```javascript
+var fs = require('fs');
+var CodeGen = require('swagger-js-codegen').CodeGen;
+
+var file = 'swagger/spec.json';
+var swagger = JSON.parse(fs.readFileSync(file, 'UTF-8'));
+var tsdCode = CodeGen.getAngularTypeScriptDefinition({ className: 'Test', swagger: swagger });
+console.log(tsdCode);
+```
+
+
+
+
 ## Grunt & Gulp task
 [There is a grunt task](https://github.com/wcandillon/grunt-swagger-js-codegen) that enables you to integrate the code generation in your development pipeline. This is extremely convenient if your application is using APIs which are documented/specified in the swagger format.
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,8 @@ For both the node and the angular code, TypeScript definition files (`.d.ts`) ca
 This includes the data types for the parameters and results of all methods. This allows static type checking of your
 API calls.
 
-TypeScript generation works similar to Javascript:
+TypeScript generation works similar to Javascript. The following example is for the angular version
+(replace `getAngularTypeScriptDefinition` with `getNodeTypeScriptDefinition` for the node version):
 ```javascript
 var fs = require('fs');
 var CodeGen = require('swagger-js-codegen').CodeGen;

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ var CodeGen = require('swagger-js-codegen').CodeGen;
 
 var file = 'swagger/spec.json';
 var swagger = JSON.parse(fs.readFileSync(file, 'UTF-8'));
-var tsdCode = CodeGen.getAngularTypeScriptDefinition({ className: 'Test', swagger: swagger, dtsRefs = ['../angular.d.ts'] });
+var tsdCode = CodeGen.getAngularTypeScriptDefinition({ className: 'Test', swagger: swagger, mustache: {imports: ['../angular.d.ts']}});
 console.log(tsdCode);
 ```
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ eg: https://cloud.google.com/appengine/docs/go/requests#Go_Request_headers
 
 ## Generating TypeScript definition files
 
-For the angular code, TypeScript definition files (`.d.ts`) can be generated that define the interface of the module.
+For both the node and the angular code, TypeScript definition files (`.d.ts`) can be generated that define the interface of the module.
 This includes the data types for the parameters and results of all methods. This allows static type checking of your
 API calls.
 
@@ -259,7 +259,7 @@ var CodeGen = require('swagger-js-codegen').CodeGen;
 
 var file = 'swagger/spec.json';
 var swagger = JSON.parse(fs.readFileSync(file, 'UTF-8'));
-var tsdCode = CodeGen.getAngularTypeScriptDefinition({ className: 'Test', swagger: swagger });
+var tsdCode = CodeGen.getAngularTypeScriptDefinition({ className: 'Test', swagger: swagger, dtsRefs = ['../angular.d.ts'] });
 console.log(tsdCode);
 ```
 

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -276,7 +276,7 @@ exports.CodeGen = {
     getCustomCode: function(opts){
         return getJSCode(opts, 'custom');
     },
-    getTypeScriptDefinition: function(opts){
+    getNodeTypeScriptDefinition: function(opts){
         return getTypeScriptDefinition(opts, function (resultType) {
             return 'Q.Promise<{response: http.IncomingMessage, body: ' + resultType + '}>';
         });

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -26,7 +26,7 @@ var getPathToMethodName = function(m, path){
     if(path === '/' || path === '') {
         return m;
     }
-    
+
     // clean url path for requests ending with '/'
     var cleanPath = path;
     if( cleanPath.indexOf('/', cleanPath.length - 1) !== -1 ) {
@@ -244,17 +244,22 @@ var getJSCode = function(opts, type) {
     return beautify(source, { indent_size: 4, max_preserve_newlines: 2 });
 };
 
-var getTypeScriptDefinition = function(opts){
-    var data = opts.swagger.swagger === '2.0' ? getViewForSwagger2(opts) : getViewForSwagger1(opts);
-    var tpl = fs.readFileSync(__dirname + '/../templates/node-typedef.mustache', 'utf-8');
-    var source = Mustache.render(tpl, data);
-    return source;
-};
+var getTypeScriptDefinition = function(opts, resultTypeFn){
+    if (opts.swagger.swagger !== '2.0') {
+        throw 'Typescript is only supported for Swagger 2.0 specs.';
+    }
 
-var getAngularTypeScriptDefinition = function(opts){
     var data = opts.swagger.swagger === '2.0' ? getViewForSwagger2(opts) : getViewForSwagger1(opts);
-    var tpl = fs.readFileSync(__dirname + '/../templates/angular-typedef.mustache', 'utf-8');
+    data.imports = opts.dtsRefs;
+    fs.writeFile('data.json', JSON.stringify(data, null, 2));
+    var tpl = fs.readFileSync(__dirname + '/../templates/typedef.mustache', 'utf-8');
     var typeTpl = fs.readFileSync(__dirname + '/../templates/type.mustache', 'utf-8');
+    data.resultFn = function () {
+        return function (tmpl, render) {
+            return resultTypeFn(render(tmpl));
+        };
+    };
+
     var source = Mustache.render(tpl, data, {type: typeTpl});
     return source;
 };
@@ -270,9 +275,13 @@ exports.CodeGen = {
         return getJSCode(opts, 'custom');
     },
     getTypeScriptDefinition: function(opts){
-        return getTypeScriptDefinition(opts);
+        return getTypeScriptDefinition(opts, function (resultType) {
+            return 'Q.Promise<{response: http.IncomingMessage, body: ' + resultType + '}>';
+        });
     },
     getAngularTypeScriptDefinition: function(opts){
-        return getAngularTypeScriptDefinition(opts);
+        return getTypeScriptDefinition(opts, function (resultType) {
+            return 'ng.IPromise<' + resultType + '>';
+        });
     }
 };

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -250,7 +250,6 @@ var getTypeScriptDefinition = function(opts, resultTypeFn){
     }
 
     var data = opts.swagger.swagger === '2.0' ? getViewForSwagger2(opts) : getViewForSwagger1(opts);
-    data.imports = opts.dtsRefs;
     var tpl = fs.readFileSync(__dirname + '/../templates/typedef.mustache', 'utf-8');
     var typeTpl = fs.readFileSync(__dirname + '/../templates/type.mustache', 'utf-8');
     data.resultFn = function () {
@@ -258,6 +257,10 @@ var getTypeScriptDefinition = function(opts, resultTypeFn){
             return resultTypeFn(render(tmpl));
         };
     };
+
+    if (opts.mustache) {
+        _.assign(data, opts.mustache);
+    }
 
     var source = Mustache.render(tpl, data, {type: typeTpl});
     return source;

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -251,7 +251,6 @@ var getTypeScriptDefinition = function(opts, resultTypeFn){
 
     var data = opts.swagger.swagger === '2.0' ? getViewForSwagger2(opts) : getViewForSwagger1(opts);
     data.imports = opts.dtsRefs;
-    fs.writeFile('data.json', JSON.stringify(data, null, 2));
     var tpl = fs.readFileSync(__dirname + '/../templates/typedef.mustache', 'utf-8');
     var typeTpl = fs.readFileSync(__dirname + '/../templates/type.mustache', 'utf-8');
     data.resultFn = function () {

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -5,6 +5,7 @@ var Mustache = require('mustache');
 var beautify = require('js-beautify').js_beautify;
 var lint = require('jshint').JSHINT;
 var _ = require('lodash');
+var typeConversion = require('./typeConversion');
 
 var camelCase = function(id) {
     if(id.indexOf('-') === -1) {
@@ -46,7 +47,8 @@ var getViewForSwagger2 = function(opts, type){
         moduleName: opts.moduleName,
         className: opts.className,
         domain: (swagger.schemes && swagger.schemes.length > 0 && swagger.host && swagger.basePath) ? swagger.schemes[0] + '://' + swagger.host + swagger.basePath : '',
-        methods: []
+        methods: [],
+        definitions: []
     };
 
     _.forEach(swagger.paths, function(api, path){
@@ -108,11 +110,36 @@ var getViewForSwagger2 = function(opts, type){
                 } else if(parameter.in === 'formData'){
                     parameter.isFormParameter = true;
                 }
+
+                // extract parameter type
+                _.merge(parameter, typeConversion.convertType(parameter));
+
                 method.parameters.push(parameter);
             });
+
+            // extract response type for 200 response, if present
+            if (_.isObject(op.responses) && _.isObject(op.responses['200'])) {
+                var resp = op.responses['200'];
+                if (resp.schema) {
+                    method.responseType = typeConversion.convertType(resp);
+                }
+            }
+
             data.methods.push(method);
         });
     });
+
+    // read definitions and their types
+    _.forEach(swagger.definitions, function(swaggerType, name) {
+        if (swaggerType.type === undefined) {
+            // sometimes the 'type' property seems to be missing. In this case, we assume 'object'
+            swaggerType.type = 'object';
+        }
+        var tsType = typeConversion.convertType(swaggerType);
+        tsType.name = name;
+        data.definitions.push(tsType);
+    });
+
     return data;
 };
 
@@ -217,6 +244,14 @@ var getTypeScriptDefinition = function(opts){
     return source;
 };
 
+var getAngularTypeScriptDefinition = function(opts){
+    var data = opts.swagger.swagger === '2.0' ? getViewForSwagger2(opts) : getViewForSwagger1(opts);
+    var tpl = fs.readFileSync(__dirname + '/../templates/angular-typedef.mustache', 'utf-8');
+    var typeTpl = fs.readFileSync(__dirname + '/../templates/type.mustache', 'utf-8');
+    var source = Mustache.render(tpl, data, {type: typeTpl});
+    return source;
+};
+
 exports.CodeGen = {
     getAngularCode: function(opts){
         return getJSCode(opts, 'angular');
@@ -229,5 +264,8 @@ exports.CodeGen = {
     },
     getTypeScriptDefinition: function(opts){
         return getTypeScriptDefinition(opts);
+    },
+    getAngularTypeScriptDefinition: function(opts){
+        return getAngularTypeScriptDefinition(opts);
     }
 };

--- a/lib/typeConversion.js
+++ b/lib/typeConversion.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var _ = require('lodash');
+
+/**
+ * Recursively converts a swagger type description into a typescript type, i.e., a model for our mustache
+ * template.
+ *
+ * Not all type are currently supported, but they should be straightforward to add.
+ *
+ * @param swaggerType a swagger type definition, i.e., the right hand side of a swagger type definition.
+ * @returns a recursive structure representing the type, which can be used as a template model.
+ */
+function convertType(swaggerType) {
+
+    var typespec = {};
+
+    if (swaggerType.hasOwnProperty('schema')) {
+        return convertType(swaggerType.schema);
+    } else if (_.isString(swaggerType.$ref)) {
+        typespec.tsType = 'ref';
+        typespec.target = swaggerType.$ref.substring(swaggerType.$ref.lastIndexOf('/') + 1);
+    } else if (swaggerType.type === 'string') {
+        typespec.tsType = 'string';
+    } else if (swaggerType.type === 'number' || swaggerType.type === 'integer') {
+        typespec.tsType = 'number';
+    } else if (swaggerType.type === 'boolean') {
+        typespec.tsType = 'boolean';
+    } else if (swaggerType.type === 'array') {
+        typespec.tsType = 'array';
+        typespec.elementType = convertType(swaggerType.items);
+    } else if (swaggerType.type === 'object') {
+        typespec.tsType = 'object';
+        typespec.properties = [];
+
+        _.forEach(swaggerType.properties, function (propertyType, propertyName) {
+            var property = convertType(propertyType);
+            property.name = propertyName;
+            typespec.properties.push(property);
+        });
+    } else {
+        // type unknown or unsupported... just map to 'any'...
+        typespec.tsType = 'any';
+    }
+
+    // Since Mustache does not provide equality checks, we need to do the case distinction via explicit booleans
+    typespec.isRef = typespec.tsType === 'ref';
+    typespec.isObject = typespec.tsType === 'object';
+    typespec.isArray = typespec.tsType === 'array';
+    typespec.isAtomic = _.contains(['string', 'number', 'boolean', 'any'], typespec.tsType);
+
+    return typespec;
+
+}
+
+module.exports.convertType = convertType;
+

--- a/templates/angular-typedef.mustache
+++ b/templates/angular-typedef.mustache
@@ -1,0 +1,16 @@
+interface {{&className}} {
+{{#methods}}
+    {{&methodName}}(parameters : {
+    {{#parameters}}
+        '{{name}}': {{>type}}
+    {{/parameters}}
+    }): ng.IPromise<{{#responseType}}{{>type}}{{/responseType}}{{^responseType}}any{{/responseType}}>;
+
+{{/methods}}
+}
+
+// data types
+{{#definitions}}
+interface {{name}} {{>type}}
+
+{{/definitions}}

--- a/templates/type.mustache
+++ b/templates/type.mustache
@@ -1,0 +1,8 @@
+{{! must use different delimiters to avoid ambiguities when delimiters directly follow a literal brace {. }}
+{{=<% %>=}}
+<%#isRef%><%target%><%/isRef%><%!
+%><%#isAtomic%><%tsType%><%/isAtomic%><%!
+%><%#isObject%>{<%#properties%>
+    '<%name%>': <%>type%><%/properties%>
+}<%/isObject%><%!
+%><%#isArray%>Array<<%#elementType%><%>type%><%/elementType%>><%/isArray%><%#isBoolean%>boolean<%/isBoolean%>

--- a/templates/typedef.mustache
+++ b/templates/typedef.mustache
@@ -1,10 +1,14 @@
+{{#imports}}
+/// <reference path="{{.}}" />
+{{/imports}}
+
 interface {{&className}} {
 {{#methods}}
     {{&methodName}}(parameters : {
     {{#parameters}}
         '{{name}}': {{>type}}
     {{/parameters}}
-    }): ng.IPromise<{{#responseType}}{{>type}}{{/responseType}}{{^responseType}}any{{/responseType}}>;
+    }): {{#resultFn}}{{#responseType}}{{>type}}{{/responseType}}{{^responseType}}any{{/responseType}}{{/resultFn}};
 
 {{/methods}}
 }

--- a/tests/angular-typescript.js
+++ b/tests/angular-typescript.js
@@ -13,7 +13,6 @@ vows.describe('Test generation of TypeScript definitions').addBatch({
             return CodeGen.getAngularTypeScriptDefinition({className: 'Petstore', swagger: swagger, dtsRefs: ['foo.d.ts', 'bar.d.ts']});
         },
         'should be equal to the expected result': function(generated){
-            fs.writeFile('actual.d.ts', generated);
             var expected = fs.readFileSync('tests/expected/petstore-simple.d.ts', {encoding: 'UTF-8'});
             assert.equal(generated, expected);
         }

--- a/tests/angular-typescript.js
+++ b/tests/angular-typescript.js
@@ -10,7 +10,7 @@ vows.describe('Test generation of TypeScript definitions').addBatch({
     'The generated code from petstore-simple.json': {
         topic: function(){
             var swagger = JSON.parse(fs.readFileSync('tests/apis/petstore-simple.json', 'UTF-8'));
-            return CodeGen.getAngularTypeScriptDefinition({className: 'Petstore', swagger: swagger, dtsRefs: ['foo.d.ts', 'bar.d.ts']});
+            return CodeGen.getAngularTypeScriptDefinition({className: 'Petstore', swagger: swagger, mustache: {imports: ['foo.d.ts', 'bar.d.ts']}});
         },
         'should be equal to the expected result': function(generated){
             var expected = fs.readFileSync('tests/expected/petstore-simple.d.ts', {encoding: 'UTF-8'});

--- a/tests/angular-typescript.js
+++ b/tests/angular-typescript.js
@@ -10,9 +10,10 @@ vows.describe('Test generation of TypeScript definitions').addBatch({
     'The generated code from petstore-simple.json': {
         topic: function(){
             var swagger = JSON.parse(fs.readFileSync('tests/apis/petstore-simple.json', 'UTF-8'));
-            return CodeGen.getAngularTypeScriptDefinition({className: 'Petstore', swagger: swagger});
+            return CodeGen.getAngularTypeScriptDefinition({className: 'Petstore', swagger: swagger, dtsRefs: ['foo.d.ts', 'bar.d.ts']});
         },
         'should be equal to the expected result': function(generated){
+            fs.writeFile('actual.d.ts', generated);
             var expected = fs.readFileSync('tests/expected/petstore-simple.d.ts', {encoding: 'UTF-8'});
             assert.equal(generated, expected);
         }

--- a/tests/angular-typescript.js
+++ b/tests/angular-typescript.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var vows = require('vows');
+var assert = require('assert');
+var fs = require('fs');
+
+var CodeGen = require('../lib/codegen').CodeGen;
+
+vows.describe('Test generation of TypeScript definitions').addBatch({
+    'The generated code from petstore-simple.json': {
+        topic: function(){
+            var swagger = JSON.parse(fs.readFileSync('tests/apis/petstore-simple.json', 'UTF-8'));
+            return CodeGen.getAngularTypeScriptDefinition({className: 'Petstore', swagger: swagger});
+        },
+        'should be equal to the expected result': function(generated){
+            var expected = fs.readFileSync('tests/expected/petstore-simple.d.ts', {encoding: 'UTF-8'});
+            assert.equal(generated, expected);
+        }
+    }
+}).export(module);

--- a/tests/apis/petstore-simple.json
+++ b/tests/apis/petstore-simple.json
@@ -1,0 +1,226 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore (Simple)",
+        "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+        "termsOfService": "http://helloreverb.com/terms/",
+        "contact": {
+            "name": "Swagger API team",
+            "email": "foo@example.com",
+            "url": "http://swagger.io"
+        },
+        "license": {
+            "name": "MIT",
+            "url": "http://opensource.org/licenses/MIT"
+        }
+    },
+    "host": "petstore.swagger.wordnik.com",
+    "basePath": "/api",
+    "schemes": [
+        "http"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/pets": {
+            "get": {
+                "description": "Returns all pets from the system that the user has access to",
+                "operationId": "findPets",
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/xml",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "tags to filter by",
+                        "required": false,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv"
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "maximum number of results to return",
+                        "required": false,
+                        "type": "integer",
+                        "format": "int32"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/pet"
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new pet in the store.  Duplicates are allowed",
+                "operationId": "addPet",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "pet",
+                        "in": "body",
+                        "description": "Pet to add to the store",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/newPet"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "schema": {
+                            "$ref": "#/definitions/pet"
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    }
+                }
+            }
+        },
+        "/pets/{id}": {
+            "get": {
+                "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+                "operationId": "findPetById",
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/xml",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of pet to fetch",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "schema": {
+                            "$ref": "#/definitions/pet"
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "deletes a single pet based on the ID supplied",
+                "operationId": "deletePet",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of pet to delete",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "pet deleted"
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "pet": {
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "newPet": {
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "errorModel": {
+            "required": [
+                "code",
+                "message"
+            ],
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/tests/expected/petstore-simple.d.ts
+++ b/tests/expected/petstore-simple.d.ts
@@ -1,0 +1,38 @@
+interface Petstore {
+    findPets(parameters : {
+        'tags': Array<string>
+        'limit': number
+    }): ng.IPromise<Array<pet>>;
+
+    addPet(parameters : {
+        'pet': newPet
+    }): ng.IPromise<pet>;
+
+    findPetById(parameters : {
+        'id': number
+    }): ng.IPromise<pet>;
+
+    deletePet(parameters : {
+        'id': number
+    }): ng.IPromise<any>;
+
+}
+
+// data types
+interface pet {
+    'id': number
+    'name': string
+    'tag': string
+}
+
+interface newPet {
+    'id': number
+    'name': string
+    'tag': string
+}
+
+interface errorModel {
+    'code': number
+    'message': string
+}
+

--- a/tests/expected/petstore-simple.d.ts
+++ b/tests/expected/petstore-simple.d.ts
@@ -1,3 +1,6 @@
+/// <reference path="foo.d.ts" />
+/// <reference path="bar.d.ts" />
+
 interface Petstore {
     findPets(parameters : {
         'tags': Array<string>

--- a/tests/generation.js
+++ b/tests/generation.js
@@ -36,7 +36,7 @@ list.forEach(function(file){
         });
         assert(typeof(result), 'string');
         if (swagger.swagger === '2.0') {
-            result = CodeGen.getTypeScriptDefinition({
+            result = CodeGen.getNodeTypeScriptDefinition({
                 className: 'Test',
                 swagger: swagger
             });

--- a/tests/generation.js
+++ b/tests/generation.js
@@ -35,11 +35,13 @@ list.forEach(function(file){
             }
         });
         assert(typeof(result), 'string');
-        result = CodeGen.getTypeScriptDefinition({
-            className: 'Test',
-            swagger: swagger
-        });
-        assert(typeof(result), 'string');
+        if (swagger.swagger === '2.0') {
+            result = CodeGen.getTypeScriptDefinition({
+                className: 'Test',
+                swagger: swagger
+            });
+            assert(typeof(result), 'string');
+        }
     };
 });
 vows.describe('Test Generation').addBatch(batch).export(module);


### PR DESCRIPTION
This pull request continues the idea of the `ts` branch, by adding the ability to generate .d.ts files for the generated angular code. In particular, types are generated for the parameters and results of all methods, which allows interacting with an API in a statically typed fashion, including IDE support like code completion.

See the test for a simple example.

Also merged master into the ts branch.