### PR TITLE
fixed issue with global "security" setting not being used

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -25,7 +25,7 @@ var getPathToMethodName = function(m, path){
     if(path === '/' || path === '') {
         return m;
     }
-    
+
     // clean url path for requests ending with '/'
     var cleanPath = path;
     if( cleanPath.indexOf('/', cleanPath.length - 1) !== -1 ) {
@@ -78,7 +78,7 @@ var getViewForSwagger2 = function(opts, type){
                 method: m.toUpperCase(),
                 isGET: m.toUpperCase() === 'GET',
                 summary: op.description,
-                isSecure: op.security !== undefined,
+                isSecure: swagger.security !== undefined || op.security !== undefined,
                 parameters: []
             };
             var params = [];


### PR DESCRIPTION
Swagger allows the "security" attribute to be specified globally for all methods. The "isSecure" setting wasn't set correctly in that situation. It was only "true" if there was a security attribute on a method, not if there was one at the swagger root.
