### PR TITLE
Allow Template Overriding and Extension

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -173,30 +173,27 @@ var getViewForSwagger1 = function(opts, type){
 };
 
 var getCode = function(opts, type) {
-    var tpl, method, request;
     // For Swagger Specification version 2.0 value of field 'swagger' must be a string '2.0'
     var data = opts.swagger.swagger === '2.0' ? getViewForSwagger2(opts, type) : getViewForSwagger1(opts, type);
     if(type === 'custom') {
         if(!_.isObject(opts.template) || !_.isString(opts.template.class)  || !_.isString(opts.template.method) || !_.isString(opts.template.request)) {
             throw new Error('Unprovided custom template. Please use the following template: template: { class: "...", method: "...", request: "..." }');
         }
-        tpl = opts.template.class;
-        method = opts.template.method;
-        request = opts.template.request;
     } else {
-        tpl = fs.readFileSync(__dirname + '/../templates/' + type + '-class.mustache', 'utf-8');
-        method = fs.readFileSync(__dirname + '/../templates/method.mustache', 'utf-8');
-        request = fs.readFileSync(__dirname + '/../templates/' + type + '-request.mustache', 'utf-8');
+        if (!_.isObject(opts.template)) {
+            opts.template = {};
+        }
+        var templates = __dirname + '/../templates/';
+        opts.template.class = opts.template.class || fs.readFileSync(templates + type + '-class.mustache', 'utf-8');
+        opts.template.method = opts.template.method || fs.readFileSync(templates + 'method.mustache', 'utf-8');
+        opts.template.request = opts.template.request || fs.readFileSync(templates + type + '-request.mustache', 'utf-8');
     }
 
     if (opts.mustache) {
         _.assign(data, opts.mustache);
     }
 
-    var source = Mustache.render(tpl, data, {
-        method: method,
-        request: request
-    });
+    var source = Mustache.render(opts.template.class, data, opts.template);
     var lintOptions = {
         node: type === 'node' || type === 'custom',
         browser: type === 'angular' || type === 'custom',


### PR DESCRIPTION
By reworking the arguments to Mustache.render, we can simplify the code, and allow for overriding of the provided templates. This also gives an extension point if a developer wants to further split in to additional templates.