### PR TITLE
Large documents cause "Too many errors" from jshint

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -200,7 +200,8 @@ var getCode = function(opts, type) {
         undef: true,
         strict: true,
         trailing: true,
-        smarttabs: true
+        smarttabs: true,
+        maxerr: 999
     };
     if (opts.esnext) {
         lintOptions.esnext = true;
@@ -210,7 +211,7 @@ var getCode = function(opts, type) {
         lint(source, lintOptions);
         lint.errors.forEach(function(error) {
             if (error.code[0] === 'E') {
-                throw new Error(lint.errors[0].reason + ' in ' + lint.errors[0].evidence);
+                throw new Error(error.reason + ' in ' + error.evidence + ' (' + error.code + ')');
             }
         });
     }


### PR DESCRIPTION
The default templates trigger quite a lot of jshint warnings. If this number gets too high, jshint records an error ("Too many errors").

After the code is generated, codegen loops that the jshint errors to look for an "E" code while ignoring the "W" codes. However when it finds an "E" code, it actually throws the *first* jshint error (usually an unrelated warning that would normally be ignored).

This change fixes both these issues.