### PR TITLE
Store properties of a body parameter in method.bodySchema.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,24 @@ methods:
             type: boolean
           isFormParameter:
             type: boolean
+      bodySchema:
+        type: object
+        properties:
+          type: array
+          description: the schema for a body parameter, null if no body parameter is defined.
+          items:
+            name:
+              type: string
+              description: the name of the property
+            type:
+              type: string
+              description: the type of the property
+            description:
+              type: string
+              description: the description of the property
+            required:
+              type: boolean
+              description: true if the property is required
 ```
 
 ####Custom Mustache Variables

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -47,6 +47,25 @@ var getPathToMethodName = function(m, path){
     return m.toLowerCase() + result[0].toUpperCase() + result.substring(1);
 };
 
+var getSchemaDefinition = function(schema) {
+    var obj = {};
+
+    if (schema.type !== 'object' || !_.isObject(schema.properties)) {
+        return obj;
+    }
+
+    obj.properties = _(schema.properties).map(function(param, key){
+        return {
+            name: key,
+            type: param.type,
+            description: param.description,
+            required: _.isArray(schema.required) && _.contains(schema.required, key)
+        };
+    }).value();
+
+    return obj;
+};
+
 var getViewForSwagger2 = function(opts, type){
     var swagger = opts.swagger;
     var authorizedMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'COPY', 'HEAD', 'OPTIONS', 'LINK', 'UNLIK', 'PURGE', 'LOCK', 'UNLOCK', 'PROPFIND'];
@@ -96,9 +115,12 @@ var getViewForSwagger2 = function(opts, type){
                 if (parameter['x-proxy-header'] && !data.isNode) {
                     return;
                 }
-                if (_.isString(parameter.$ref)) {
+                if (parameter.in !== 'body' && _.isString(parameter.$ref)) {
                     var segments = parameter.$ref.split('/');
                     parameter = swagger.parameters[segments.length === 1 ? segments[0] : segments[2] ];
+                } else if (parameter.in === 'body' && _.isObject(parameter.schema) && _.isString(parameter.schema.$ref)) {
+                    var schemaSegments = parameter.schema.$ref.split('/');
+                    parameter.schema = swagger.definitions[schemaSegments.length === 1 ? schemaSegments[0] : schemaSegments[2] ];
                 }
                 parameter.camelCaseName = camelCase(parameter.name);
                 if(parameter.enum && parameter.enum.length === 1) {
@@ -107,6 +129,9 @@ var getViewForSwagger2 = function(opts, type){
                 }
                 if(parameter.in === 'body'){
                     parameter.isBodyParameter = true;
+                    if (_.isObject(parameter.schema)) {
+                        method.bodySchema = getSchemaDefinition(parameter.schema);
+                    }
                 } else if(parameter.in === 'path'){
                     parameter.isPathParameter = true;
                 } else if(parameter.in === 'query'){
@@ -210,7 +235,7 @@ var getCode = function(opts, type) {
     if (opts.esnext) {
         lintOptions.esnext = true;
     }
-    
+
     if (opts.lint === undefined || opts.lint === true) {
         lint(source, lintOptions);
         lint.errors.forEach(function(error) {


### PR DESCRIPTION

```yaml
/pets/cat:
    post:
      parameters:
        - name: ''
          in: body
          schema:
            $ref: '#/definitions/Cat'
          required: true

paths:
  definitions:
    Cat:
      type: object
      properties:
        name:
          description: 'Name of cat'
          type: string
        sex:
          description: 'Sex of cat, male or female'
          type: string
      required: ['sex']
```

produces the following following method.bodySchema:
```yaml
- name: name
  type: string
  description: 'Name of cat'
  required: false
- name: sex
  type: string
  description: 'Sex of cat, male or female'
  required: true
```

This is similar to pull request #94 but only adds bodySchema.