### PR TITLE
simple last slash removal

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -31,10 +31,7 @@ var getPathToMethodName = function(m, path){
     }
 
     // clean url path for requests ending with '/'
-    var cleanPath = path;
-    if( cleanPath.indexOf('/', cleanPath.length - 1) !== -1 ) {
-        cleanPath = cleanPath.substring(0, cleanPath.length - 1);
-    }
+    var cleanPath = path.replace(/\/$/, '');
 
     var segments = cleanPath.split('/').slice(1);
     segments = _.transform(segments, function (result, segment) {


### PR DESCRIPTION
i think this shorter way of removing the last slash is simpler thus easier to read :)

if the path doesn't have the last slash, nothing will be replaced.. the regex will simply not match anything