### PR TITLE
simplify regex to match application/json

### DIFF
--- a/templates/node-request.mustache
+++ b/templates/node-request.mustache
@@ -15,7 +15,7 @@ request(req, function(error, response, body){
     if(error) {
         deferred.reject(error);
     } else {
-        if(/^application\/(.*\\+)?json/.test(response.headers['content-type'])) {
+        if(/application\/json/.test(response.headers['content-type'])) {
             try {
                 body = JSON.parse(body);
             } catch(e) {


### PR DESCRIPTION
according to ietf http://www.ietf.org/rfc/rfc4627.txt JSON content type is `application/json` so I think that we should simply match that. Other header than that, you can't be sure that is going to be json parseable.

even a simpler way would be

```js
if(response.headers['content-type'] === 'application/json')
```

however I am not sure if multiple headers could come... but even that would be weird.

what are your thoughts?