### PR TITLE
Sanitize intput to convertType

### DIFF
--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -14,6 +14,9 @@ var _ = require('lodash');
 function convertType(swaggerType) {
 
     var typespec = {};
+    
+    // sanitize input
+    swaggerType = swaggerType || {};
 
     if (swaggerType.hasOwnProperty('schema')) {
         return convertType(swaggerType.schema);
@@ -50,7 +53,6 @@ function convertType(swaggerType) {
     typespec.isAtomic = _.contains(['string', 'number', 'boolean', 'any'], typespec.tsType);
 
     return typespec;
-
 }
 
 module.exports.convertType = convertType;


### PR DESCRIPTION
I used swagger-js-codegen on a swagger-file that contained an array with missing items-property that caused swagger-js-codegen to crash.

Therefore I sanitize the input to convertType to default to an empty object when called with undefined.