### PR TITLE
method summary & externalDocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 .DS_Store
 *.swp
+*.iml
 .idea

--- a/README.md
+++ b/README.md
@@ -130,7 +130,17 @@ methods:
         description: true if method === 'GET'
       summary:
         type: string
-        description: Provided by the 'description' field in the schema
+        description: Provided by the 'description' or 'summary' field in the schema
+      externalDocs:
+        type: object
+        properties:
+          url:
+            type: string
+            description: The URL for the target documentation. Value MUST be in the format of a URL.
+            required: true
+          description:
+            type: string
+            description: A short description of the target documentation. GitHub-Markdown syntax can be used for rich text representation.
       isSecure:
         type: boolean
         description: true if the 'security' is defined for the method in the schema

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -89,7 +89,8 @@ var getViewForSwagger2 = function(opts, type){
                 methodName:  op.operationId ? normalizeName(op.operationId) : getPathToMethodName(opts, m, path),
                 method: m.toUpperCase(),
                 isGET: m.toUpperCase() === 'GET',
-                summary: op.description,
+                summary: op.description || op.summary,
+                externalDocs: op.externalDocs,
                 isSecure: swagger.security !== undefined || op.security !== undefined,
                 parameters: [],
                 headers: []

--- a/templates/typescript-method.mustache
+++ b/templates/typescript-method.mustache
@@ -1,11 +1,13 @@
 /**
 * {{&summary}}
 * @method
+{{#externalDocs}}
+* @see {@link {{&url}}|{{#description}}{{&description}}{{/description}}{{^description}}External docs{{/description}}}
+{{/externalDocs}}
 * @name {{&className}}#{{&methodName}}
 {{#parameters}}
     {{^isSingleton}} * @param {{=<% %>=}}{<%&type%>}<%={{ }}=%> {{&camelCaseName}} - {{&description}}{{/isSingleton}}
 {{/parameters}}
-*
 */
 {{&methodName}}(parameters: {
 {{#parameters}}{{^isSingleton}}'{{&camelCaseName}}'{{&cardinality}}: {{> type}},
@@ -24,6 +26,12 @@
 {{/headers}}
 
 {{#parameters}}
+    {{#required}}
+        if(parameters['{{&camelCaseName}}'] === undefined){
+            reject(new Error('Missing required {{&paramType}} parameter: {{&camelCaseName}}'));
+            return;
+        }
+    {{/required}}
 
     {{#isQueryParameter}}
         {{#isSingleton}}
@@ -38,9 +46,14 @@
                 });
             {{/isPatternType}}
             {{^isPatternType}}
+                {{#required}}
+                queryParameters['{{&name}}'] = parameters['{{&camelCaseName}}'];
+                {{/required}}
+                {{^required}}
                 if(parameters['{{&camelCaseName}}'] !== undefined){
                     queryParameters['{{&name}}'] = parameters['{{&camelCaseName}}'];
                 }
+                {{/required}}
             {{/isPatternType}}
         {{/isSingleton}}
     {{/isQueryParameter}}
@@ -54,16 +67,26 @@
             headers['{{&name}}'] = '{{&singleton}}';
         {{/isSingleton}}
         {{^isSingleton}}
+            {{#required}}
+            headers['{{&name}}'] = parameters['{{&camelCaseName}}'];
+            {{/required}}
+            {{^required}}
             if(parameters['{{&camelCaseName}}'] !== undefined){
                 headers['{{&name}}'] = parameters['{{&camelCaseName}}'];
             }
+            {{/required}}
         {{/isSingleton}}
     {{/isHeaderParameter}}
 
     {{#isBodyParameter}}
+        {{#required}}
+        body = parameters['{{&camelCaseName}}'];
+        {{/required}}
+        {{^required}}
         if(parameters['{{&camelCaseName}}'] !== undefined){
             body = parameters['{{&camelCaseName}}'];
         }
+        {{/required}}
     {{/isBodyParameter}}
 
     {{#isFormParameter}}
@@ -71,19 +94,16 @@
             form['{{&name}}'] = '{{&singleton}}';
         {{/isSingleton}}
         {{^isSingleton}}
+            {{#required}}
+            form['{{&name}}'] = parameters['{{&camelCaseName}}'];
+            {{/required}}
+            {{^required}}
             if(parameters['{{&camelCaseName}}'] !== undefined){
                 form['{{&name}}'] = parameters['{{&camelCaseName}}'];
             }
+            {{/required}}
         {{/isSingleton}}
     {{/isFormParameter}}
-
-    {{#required}}
-        if(parameters['{{&camelCaseName}}'] === undefined){
-            reject(new Error('Missing required {{&paramType}} parameter: {{&camelCaseName}}'));
-            return;
-        }
-    {{/required}}
-
 {{/parameters}}
 
 if(parameters.$queryParameters) {

--- a/templates/typescript-method.mustache
+++ b/templates/typescript-method.mustache
@@ -26,12 +26,6 @@
 {{/headers}}
 
 {{#parameters}}
-    {{#required}}
-        if(parameters['{{&camelCaseName}}'] === undefined){
-            reject(new Error('Missing required {{&paramType}} parameter: {{&camelCaseName}}'));
-            return;
-        }
-    {{/required}}
 
     {{#isQueryParameter}}
         {{#isSingleton}}
@@ -46,14 +40,9 @@
                 });
             {{/isPatternType}}
             {{^isPatternType}}
-                {{#required}}
-                queryParameters['{{&name}}'] = parameters['{{&camelCaseName}}'];
-                {{/required}}
-                {{^required}}
                 if(parameters['{{&camelCaseName}}'] !== undefined){
                     queryParameters['{{&name}}'] = parameters['{{&camelCaseName}}'];
                 }
-                {{/required}}
             {{/isPatternType}}
         {{/isSingleton}}
     {{/isQueryParameter}}
@@ -67,26 +56,16 @@
             headers['{{&name}}'] = '{{&singleton}}';
         {{/isSingleton}}
         {{^isSingleton}}
-            {{#required}}
-            headers['{{&name}}'] = parameters['{{&camelCaseName}}'];
-            {{/required}}
-            {{^required}}
             if(parameters['{{&camelCaseName}}'] !== undefined){
                 headers['{{&name}}'] = parameters['{{&camelCaseName}}'];
             }
-            {{/required}}
         {{/isSingleton}}
     {{/isHeaderParameter}}
 
     {{#isBodyParameter}}
-        {{#required}}
-        body = parameters['{{&camelCaseName}}'];
-        {{/required}}
-        {{^required}}
         if(parameters['{{&camelCaseName}}'] !== undefined){
             body = parameters['{{&camelCaseName}}'];
         }
-        {{/required}}
     {{/isBodyParameter}}
 
     {{#isFormParameter}}
@@ -94,16 +73,19 @@
             form['{{&name}}'] = '{{&singleton}}';
         {{/isSingleton}}
         {{^isSingleton}}
-            {{#required}}
-            form['{{&name}}'] = parameters['{{&camelCaseName}}'];
-            {{/required}}
-            {{^required}}
             if(parameters['{{&camelCaseName}}'] !== undefined){
                 form['{{&name}}'] = parameters['{{&camelCaseName}}'];
             }
-            {{/required}}
         {{/isSingleton}}
     {{/isFormParameter}}
+
+    {{#required}}
+        if(parameters['{{&camelCaseName}}'] === undefined){
+            reject(new Error('Missing required {{&paramType}} parameter: {{&camelCaseName}}'));
+            return;
+        }
+    {{/required}}
+
 {{/parameters}}
 
 if(parameters.$queryParameters) {

--- a/tests/apis/test.json
+++ b/tests/apis/test.json
@@ -13,6 +13,10 @@
             "head": {
                 "tags": ["User"],
                 "summary": "Check whether a model instance exists in the data source.",
+                "externalDocs": {
+                    "description": "More info on the WIKI",
+                    "url": "https://example.atlassian.net/wiki/pages/example"
+                },
                 "operationId": "User.exists__head_Users_{id}",
                 "parameters": [{
                     "name": "id",


### PR DESCRIPTION
These changes allow the method summary to be provided by the schema's `description` or `summary` fields.  I have also added support for method.externalDocs, as they are provided in our schemas.