### PR TITLE
Extended library with Information about "responses"

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ methods:
             type: boolean
           isFormParameter:
             type: boolean
+      responses:
+		type: object
+		description: Includes all defined response-codes and its JSONs schema
+		additionalProperties:
+		  type: object
+		  description: See the 'Response Object' section in the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#response-object)
 ```
 
 ####Custom Mustache Variables

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -150,9 +150,7 @@ var getViewForSwagger2 = function(opts, type){
                 method.parameters.push(parameter);
             });
 			
-			if(_.isPlainObject(op.responses)) {
-				method.responses = op.responses;
-			}
+			method.responses = op.responses;
 			
             data.methods.push(method);
         });

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -149,6 +149,11 @@ var getViewForSwagger2 = function(opts, type){
                 parameter.cardinality = parameter.required ? '' : '?';
                 method.parameters.push(parameter);
             });
+			
+			if(_.isPlainObject(op.responses)) {
+				method.responses = op.responses;
+			}
+			
             data.methods.push(method);
         });
     });


### PR DESCRIPTION
I am using this library to implement an awesome JS-library that should validate all requests and responses against the given JSON-schema from the swagger-File. While I could do this for requests (since the parameters are there) I can't do it for responses, because the different responses get lost during the lib-internal transformation.

Thus, I added the responses just as they have been defined in the swagge-file to each "method" to enable encouraged developers to add some response-based features in their generated JS-library (especially using "getCustomCode").