### PR TITLE
Content-type header works like the accept header, with support for arrays of values

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -60,7 +60,7 @@ var produceHeaderKeyValue = function (name, values) {
     header.name = name;
     header.value.push(values.map(function (value) { return '\'' + value + '\''; }).join(', '));
     return header;
-}
+};
 
 var getViewForSwagger2 = function(opts, type){
     var swagger = opts.swagger;

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -105,12 +105,12 @@ var getViewForSwagger2 = function(opts, type){
             };
 
             if (op.produces) {
-                method.headers.push(produceHeaderKeyValue("Accept", op.produces));
+                method.headers.push(produceHeaderKeyValue('Accept', op.produces));
             }
           
             var consumes = op.consumes || swagger.consumes;
             if (consumes) {
-                method.headers.push(produceHeaderKeyValue("Content-Type", consumes));
+                method.headers.push(produceHeaderKeyValue('Content-Type', consumes));
             }
 
             var params = [];

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -54,6 +54,14 @@ var getPathToMethodName = function(opts, m, path){
     return m.toLowerCase() + result[0].toUpperCase() + result.substring(1);
 };
 
+var produceHeaderKeyValue = function (name, values) {
+    var header = [];
+    header.value = [];
+    header.name = name;
+    header.value.push(values.map(function (value) { return '\'' + value + '\''; }).join(', '));
+    return header;
+}
+
 var getViewForSwagger2 = function(opts, type){
     var swagger = opts.swagger;
     var authorizedMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'COPY', 'HEAD', 'OPTIONS', 'LINK', 'UNLIK', 'PURGE', 'LOCK', 'UNLOCK', 'PROPFIND'];
@@ -96,19 +104,13 @@ var getViewForSwagger2 = function(opts, type){
                 headers: []
             };
 
-            if(op.produces) {
-                var headers = [];
-                headers.value = [];
-
-                headers.name = 'Accept';
-                headers.value.push(op.produces.map(function(value) { return '\'' + value + '\''; }).join(', '));
-                
-                method.headers.push(headers);
+            if (op.produces) {
+                method.headers.push(produceHeaderKeyValue("Accept", op.produces));
             }
           
             var consumes = op.consumes || swagger.consumes;
-            if(consumes) {
-                method.headers.push({name: 'Content-Type', value: '\'' + consumes + '\'' });
+            if (consumes) {
+                method.headers.push(produceHeaderKeyValue("Content-Type", consumes));
             }
 
             var params = [];


### PR DESCRIPTION
The content-type header did not support an array of header values (for example `headers['Content-Type'] = ['application/json', 'text/json', 'application/xml', 'text/xml', 'application/x-www-form-urlencoded'];`) it would just produce a single string (i.e. `headers['Content-Type'] = 'application/json, text/json, application/xml, text/xml, application/x-www-form-urlencoded;`.

Which is incorrect, it should be an array as Accept does. Refactored out the code from accept to a function (`produceHeaderKeyValue`) and changed Accept & Content-Type headers to use that one function to generate their own header values. 
