### PR TITLE
parse definitions from Swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,24 @@ methods:
             type: boolean
           isFormParameter:
             type: boolean
+definitions:
+  type: array
+  description: Array with all Types defined in defintions
+  items:
+    type: object
+    properties:
+      tsType:
+        type: string
+      isRef:
+        type: boolean
+      isObject:
+        type: boolean
+      isArray:
+        type: boolean
+      isAtomic:
+        type: boolean
+      name:
+        type: string
 ```
 
 ####Custom Mustache Variables

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -65,7 +65,8 @@ var getViewForSwagger2 = function(opts, type){
         className: opts.className,
         imports: opts.imports,
         domain: (swagger.schemes && swagger.schemes.length > 0 && swagger.host && swagger.basePath) ? swagger.schemes[0] + '://' + swagger.host + swagger.basePath.replace(/\/+$/g,'') : '',
-        methods: []
+        methods: [],
+        definitions: []
     };
 
     _.forEach(swagger.paths, function(api, path){
@@ -157,6 +158,15 @@ var getViewForSwagger2 = function(opts, type){
             data.methods.push(method);
         });
     });
+
+    _.forEach(swagger.definitions, function(typeInfo, typeName) {
+        typeInfo.type = typeInfo.type || 'object';
+        
+        var tsType = ts.convertType(typeInfo);
+        tsType.name = typeName;
+        data.definitions.push(tsType);
+    });
+
     return data;
 };
 

--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -15,6 +15,9 @@ function convertType(swaggerType) {
 
     var typespec = {};
 
+    // sanitize input
+    swaggerType = swaggerType || {};
+
     if (swaggerType.hasOwnProperty('schema')) {
         return convertType(swaggerType.schema);
     } else if (_.isString(swaggerType.$ref)) {

--- a/templates/typescript-definitions-only.mustache
+++ b/templates/typescript-definitions-only.mustache
@@ -1,0 +1,3 @@
+{{#definitions}}
+interface {{name}} {{>type}}
+{{/definitions}}


### PR DESCRIPTION
Added simple code to also parse the definitions found in swagger-files.


Sample template to output nothing but the definitions:
```
{{#definitions}}
interface {{name}} {{>type}}
{{/definitions}}
```

```
        var swaggerJson = JSON.parse(response);
        var typeTemplate = fs.readFileSync(__dirname + '/templates/typescript-definitions-only.mustache', 'utf-8');
        var opts = {
            swagger: swaggerJson,
            template: {
                class: typeTemplate
            }
        };
        var tsDefinitions = CodeGen.getTypescriptCode(opts);
        var defFile = fs.createWriteStream('./myDefinitions.d.ts');
        defFile.write(tsDefinitions);
```

The change in lib/typescript.js is for a special case I encountered with a swagger file where a parameter was defined as an array but misses the items-property describing the elements of the array. So I added this line to sanitize the input and default to a safe option instead of crashing when it tries to call 'hasOwnProperty' of undefined.
