### PR TITLE
Add modern license to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,7 @@
     "email": "w@28.io",
     "url": "http://28.io"
   },
-  "licenses": [
-    {
-      "type": "Apache 2",
-      "url": "https://github.com/wcandillon/swagger-js-codegen/blob/master/LICENSE"
-    }
-  ],
+  "license": "Apache-2.0",
   "homepage": "https://github.com/wcandillon/swagger-js-codegen",
   "dependencies": {
     "js-beautify": "~1.5.1",


### PR DESCRIPTION
See https://docs.npmjs.com/files/package.json#license

Without this change newer versions of `npm` write out a warning about the
license missing.