### PR TITLE
Fix tests when grunt isn't installed globally.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,14 +36,14 @@
     "mustache": "^2.0.0"
   },
   "devDependencies": {
-    "grunt": "~0.4.4",
-    "grunt-contrib-jshint": "~0.9.2",
-    "grunt-vows": "~0.4.1",
-    "q": "~1.0.1",
     "final-fs": "~1.6.0",
-    "matchdep": "~0.3.0",
-    "vows": "~0.7.0",
+    "grunt": "~0.4.4",
+    "grunt-contrib-jshint": "^0.9.2",
     "grunt-jsonlint": "~1.0.4",
-    "request": "~2.40.0"
+    "grunt-vows": "~0.4.1",
+    "matchdep": "~0.3.0",
+    "q": "~1.0.1",
+    "request": "~2.40.0",
+    "vows": "~0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "devDependencies": {
     "final-fs": "~1.6.0",
-    "grunt": "~0.4.4",
-    "grunt-contrib-jshint": "^0.9.2",
+    "grunt": "^1.0.1",
+    "grunt-contrib-jshint": "^1.1.0",
     "grunt-jsonlint": "~1.0.4",
     "grunt-vows": "~0.4.1",
     "matchdep": "~0.3.0",


### PR DESCRIPTION
Checking out the project, running `npm install`, and then running `npm test` fails if `grunt` isn't installed globally.
    
Observed with this version of `npm`:
```
$ npm -version
3.10.3
```
    
Requires https://github.com/wcandillon/swagger-js-codegen/pull/158