### PR TITLE
Add typescript compilation to tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 *.swp
 *.iml
 .idea
+
+tmp-*

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "matchdep": "^1.0.1 ",
     "q": "^1.0.1",
     "request": "^2.40.0",
+    "superagent": "^3.3.1",
     "tmp": "0.0.31",
     "typescript": "^2.1.4",
     "vows": "^0.8.1"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "1.7.12",
   "description": "A Swagger codegen for JavaScript",
   "scripts": {
-    "test": "grunt"
+    "test": "grunt",
+    "clean": "rm -rf tmp-*"
   },
   "bugs": {
     "url": "https://github.com/wcandillon/swagger-js-codegen/issues"
@@ -39,6 +40,8 @@
     "matchdep": "^1.0.1 ",
     "q": "^1.0.1",
     "request": "^2.40.0",
+    "tmp": "0.0.31",
+    "typescript": "^2.1.4",
     "vows": "^0.8.1"
   }
 }

--- a/templates/typescript-method.mustache
+++ b/templates/typescript-method.mustache
@@ -29,7 +29,7 @@ $domain?: string
         {{/isQueryParameter}}
 
         {{#isPathParameter}}
-            path = path.replace('{{=<% %>=}}{<%&name%>}<%={{ }}=%>', parameters['{{&camelCaseName}}']);
+            path = path.replace('{{=<% %>=}}{<%&name%>}<%={{ }}=%>', `${parameters['{{&camelCaseName}}']}`);
         {{/isPathParameter}}
     {{/parameters}}
     
@@ -104,7 +104,7 @@ $domain?: string
     {{/isQueryParameter}}
 
     {{#isPathParameter}}
-        path = path.replace('{{=<% %>=}}{<%&name%>}<%={{ }}=%>', parameters['{{&camelCaseName}}']);
+        path = path.replace('{{=<% %>=}}{<%&name%>}<%={{ }}=%>', `${parameters['{{&camelCaseName}}']}`);
     {{/isPathParameter}}
 
     {{#isHeaderParameter}}

--- a/tests/apis/test.json
+++ b/tests/apis/test.json
@@ -39,7 +39,7 @@
         }
    },
     "definitions": {
-        "x-any": {
+        "xany": {
             "properties": {}
         },
         "ObjectID": {

--- a/tests/generation.js
+++ b/tests/generation.js
@@ -10,15 +10,23 @@ var tmp = require('tmp');
 var CodeGen = require('../lib/codegen').CodeGen;
 
 function compileString(testName, input) {
-    var tmpDir = tmp.dirSync({ dir: './', unsafeCleanup: true, keep: true});
-    var tmpFile = tmp.fileSync({postfix : '.ts', dir: tmpDir.name, keep: true});
+    var tmpDir = tmp.dirSync({
+        dir: './',
+        unsafeCleanup: true,
+        keep: true
+    });
+    var tmpFile = tmp.fileSync({
+        postfix: '.ts',
+        dir: tmpDir.name,
+        keep: true
+    });
     fs.writeFileSync(tmpFile.fd, input);
 
     var program = ts.createProgram([tmpFile.name], {
-				module: ts.ModuleKind.CommonJS,
-				target: ts.ScriptTarget.ES2016, // Makes promises resolve
-				moduleResolution: ts.ModuleResolutionKind.NodeJs // ensure we can use node_modules
-		});
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2016, // Makes promises resolve
+        moduleResolution: ts.ModuleResolutionKind.NodeJs // ensure we can use node_modules
+    });
     var emitResult = program.emit();
 
     var allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
@@ -28,18 +36,18 @@ function compileString(testName, input) {
         var line = lineAndCharacter.line;
         var character = lineAndCharacter.character;
         var message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
-			  var outputLine = diagnostic.file.text.split('\n')[line];
-        console.log('\n' + testName + ': (' + (line+1) + ',' + (character + 1) + '): ' + message);
-			  console.log('     ERROR line: ' + outputLine.trim());
+        var outputLine = diagnostic.file.text.split('\n')[line];
+        console.log('\n' + testName + ': (' + (line + 1) + ',' + (character + 1) + '): ' + message);
+        console.log('     ERROR line: ' + outputLine.trim());
     });
 
-	  var errorsSeen = allDiagnostics.length !== 0;
-	  if (errorsSeen) {
-			  console.log('     ERRORS seen, generated code preserved in: ' + tmpFile.name);
-		} else {
+    var errorsSeen = allDiagnostics.length !== 0;
+    if (errorsSeen) {
+        console.log('     ERRORS seen, generated code preserved in: ' + tmpFile.name);
+    } else {
         tmpFile.removeCallback();
         tmpDir.removeCallback();
-		}
+    }
     return !errorsSeen;
 }
 

--- a/tests/generation.js
+++ b/tests/generation.js
@@ -4,8 +4,44 @@ var assert = require('assert');
 var vows = require('vows');
 var fs = require('fs');
 var ffs = require('final-fs');
+var ts = require('typescript');
+var tmp = require('tmp');
 
 var CodeGen = require('../lib/codegen').CodeGen;
+
+function compileString(testName, input) {
+    var tmpDir = tmp.dirSync({ dir: './', unsafeCleanup: true, keep: true});
+    var tmpFile = tmp.fileSync({postfix : '.ts', dir: tmpDir.name, keep: true});
+    fs.writeFileSync(tmpFile.fd, input);
+
+    var program = ts.createProgram([tmpFile.name], {
+				module: ts.ModuleKind.CommonJS,
+				target: ts.ScriptTarget.ES2016, // Makes promises resolve
+				moduleResolution: ts.ModuleResolutionKind.NodeJs // ensure we can use node_modules
+		});
+    var emitResult = program.emit();
+
+    var allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
+
+    allDiagnostics.forEach(function(diagnostic) {
+        var lineAndCharacter = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+        var line = lineAndCharacter.line;
+        var character = lineAndCharacter.character;
+        var message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+			  var outputLine = diagnostic.file.text.split('\n')[line];
+        console.log('\n' + testName + ': (' + (line+1) + ',' + (character + 1) + '): ' + message);
+			  console.log('     ERROR line: ' + outputLine.trim());
+    });
+
+	  var errorsSeen = allDiagnostics.length !== 0;
+	  if (errorsSeen) {
+			  console.log('     ERRORS seen, generated code preserved in: ' + tmpFile.name);
+		} else {
+        tmpFile.removeCallback();
+        tmpDir.removeCallback();
+		}
+    return !errorsSeen;
+}
 
 var batch = {};
 var list = ffs.readdirSync('tests/apis');
@@ -40,6 +76,7 @@ list.forEach(function(file){
                 swagger: swagger,
                 lint: false
             });
+            assert(compileString('typescript generation: ' + file, result), 'typescript compilation failed');
             assert(typeof(result), 'string');
         }
         result = CodeGen.getCustomCode({


### PR DESCRIPTION
By ensuring that typescript compilation actually succeeds, this can catch
errors in the generated typescript code.

If a test fails, it also outputs errors like:

``` 
typescript generation: tests/apis/test.json: (7,8): '=' expected.
     ERROR line: type x - any = any;

typescript generation: tests/apis/test.json: (7,10): Cannot find name 'any'.
     ERROR line: type x - any = any;

typescript generation: tests/apis/test.json: (7,14): ';' expected.
     ERROR line: type x - any = any;

typescript generation: tests/apis/test.json: (7,16): Cannot find name 'any'.
     ERROR line: type x - any = any;
     ERRORS seen, generated code preserved in: tmp-14119f8ix0j7tPPOJ/tmp-14119xCh86tpdRHqL.ts
``` 

or 

```
typescript generation: tests/apis/uber.json: (160,29): Argument of type '"{id}"' is not assignable to parameter of type 'RegExp'.
     ERROR line: path = path.replace('{id}', parameters['id']);

typescript generation: tests/apis/uber.json: (205,33): Argument of type '"{id}"' is not assignable to parameter of type 'RegExp'.
     ERROR line: path = path.replace('{id}', parameters['id']);
   generated code preserved in:tmp-13001eulrYDIm346L/tmp-13001X0iZIo8ED9z9.ts
```

These can be cleaned up by a call to `npm run clean`.

*Note:* the above errors were also fixed in this PR.