### PR TITLE
* Added support for 'allOf' in type generation #162

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -140,7 +140,7 @@ var getViewForSwagger2 = function(opts, type){
     _.forEach(swagger.definitions, function(definition, name){
         data.definitions.push({
             name: name,
-            tsType: ts.convertType(definition)
+            tsType: ts.convertType(definition, swagger)
         });
     });
 

--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -11,7 +11,7 @@ var _ = require('lodash');
  * @param swaggerType a swagger type definition, i.e., the right hand side of a swagger type definition.
  * @returns a recursive structure representing the type, which can be used as a template model.
  */
-function convertType(swaggerType) {
+function convertType(swaggerType, swagger) {
 
     var typespec = {};
 
@@ -35,6 +35,21 @@ function convertType(swaggerType) {
     } else if (swaggerType.type === 'object') {
         typespec.tsType = 'object';
         typespec.properties = [];
+        if (swaggerType.allOf) {
+            _.forEach(swaggerType.allOf, function (ref) {
+                let refSegments = ref.$ref.split('/');
+                let name = refSegments[refSegments.length - 1];
+                _.forEach(swagger.definitions, function(definition, definitionName){
+                    if (definitionName === name) {
+                        _.forEach(definition.properties, function (propertyType, propertyName) {
+                            var property = convertType(propertyType);
+                            property.name = propertyName;
+                            typespec.properties.push(property);
+                        });
+                    }
+                });
+            });
+        }
 
         _.forEach(swaggerType.properties, function (propertyType, propertyName) {
             var property = convertType(propertyType);


### PR DESCRIPTION
* Passed swagger object into convertType to allow reference to other types
* Added check for If type is object and swaggerType has allOf defined, iterate over each ref and recursively call convertType on it and add it’s children to the current type

fixes #162