### PR TITLE
Fixed generation of ‘Accept’ header

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -75,15 +75,12 @@ var getViewForSwagger2 = function(opts, type){
             };
 
             if(op.produces) {
-                var headers = [];
-                headers.value = [];
-
-                headers.name = 'Accept';
-                headers.value.push(op.produces.map(function(value) { return '\'' + value + '\''; }).join(', '));
-                
-                method.headers.push(headers);
+                method.headers.push({
+                  name: 'Accept',
+                  value: `'${op.produces.map(function(value) { return value; }).join(', ')}'`,
+                });
             }
-          
+
             var consumes = op.consumes || swagger.consumes;
             if(consumes) {
                 method.headers.push({name: 'Content-Type', value: '\'' + consumes + '\'' });
@@ -178,7 +175,7 @@ var getViewForSwagger1 = function(opts, type){
 
                 headers.name = 'Accept';
                 headers.value.push(op.produces.map(function(value) { return '\'' + value + '\''; }).join(', '));
-                
+
                 method.headers.push(headers);
             }
 


### PR DESCRIPTION
The code that creates the Accept header was building an array.  This is inconsistent with the other headers which are all strings.  This update fixed that.