### PR TITLE
allOf fixes to support multilevel inheritance + notype treated as object

### DIFF
--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -33,7 +33,7 @@ function convertType(swaggerType, swagger) {
     } else if (swaggerType.type === 'array') {
         typespec.tsType = 'array';
         typespec.elementType = convertType(swaggerType.items);
-    } else if (swaggerType.type === 'object') {
+    } else /*if (swaggerType.type === 'object')*/ { //remaining types are created as objects
         if (swaggerType.minItems >= 0 && swaggerType.hasOwnProperty('title') && !swaggerType.$ref) {
             typespec.tsType = 'any';
         }
@@ -42,17 +42,19 @@ function convertType(swaggerType, swagger) {
             typespec.properties = [];
             if (swaggerType.allOf) {
                 _.forEach(swaggerType.allOf, function (ref) {
-                    let refSegments = ref.$ref.split('/');
-                    let name = refSegments[refSegments.length - 1];
-                    _.forEach(swagger.definitions, function(definition, definitionName){
-                        if (definitionName === name) {
-                            _.forEach(definition.properties, function (propertyType, propertyName) {
-                                var property = convertType(propertyType);
-                                property.name = propertyName;
-                                typespec.properties.push(property);
-                            });
-                        }
-                    });
+                    if(ref.$ref) {
+                        let refSegments = ref.$ref.split('/');
+                        let name = refSegments[refSegments.length - 1];
+                        _.forEach(swagger.definitions, function (definition, definitionName) {
+                            if (definitionName === name) {
+                                var property = convertType(definition, swagger);
+                                typespec.properties.push(...property.properties);
+                            }
+                        });
+                    } else {
+                        var property = convertType(ref);
+                        typespec.properties.push(...property.properties);
+                    }
                 });
             }
 
@@ -62,10 +64,10 @@ function convertType(swaggerType, swagger) {
                 typespec.properties.push(property);
             });
         }
-    } else {
-        // type unknown or unsupported... just map to 'any'...
-        typespec.tsType = 'any';
-    }
+    } /*else {
+     // type unknown or unsupported... just map to 'any'...
+     typespec.tsType = 'any';
+     }*/
 
     // Since Mustache does not provide equality checks, we need to do the case distinction via explicit booleans
     typespec.isRef = typespec.tsType === 'ref';
@@ -78,3 +80,4 @@ function convertType(swaggerType, swagger) {
 }
 
 module.exports.convertType = convertType;
+


### PR DESCRIPTION
The previous version would only navigate one level up on the inheritance chain - this has been changed in order to allow multilevel inheritance by recursively navigating refs. Also according to the swagger spec, definitions using allOf don't have to specify a type but this was enforced on the previous version. In the current version, anything with unspecified type (including definitions with allOf) are treated as objects.