### PR TITLE
Added support for accessing the typescript types for a successful response in the mustache templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ methods:
             type: boolean
           isFormParameter:
             type: boolean
+      successfulResponseType:
+        type: string
+        description: The type of a successful response. Defaults to any for non-parsable types or Swagger 1.0 spec files
 ```
 
 #### Custom Mustache Variables

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -7,7 +7,7 @@ var lint = require('jshint').JSHINT;
 var _ = require('lodash');
 var ts = require('./typescript');
 
-var defaultSuccessfulResponseType = "any";
+var defaultSuccessfulResponseType = 'any';
 
 var normalizeName = function(id) {
     return id.replace(/\.|\-|\{|\}/g, '_');
@@ -80,7 +80,7 @@ var getViewForSwagger2 = function(opts, type){
 					
             var successfulResponseType;
             try {
-                successfulResponseType = ts.convertType(op.responses["200"]).target || defaultSuccessfulResponseType;
+                successfulResponseType = ts.convertType(op.responses['200']).target || defaultSuccessfulResponseType;
             } catch (error) {
                 successfulResponseType = defaultSuccessfulResponseType;
             }

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -7,6 +7,8 @@ var lint = require('jshint').JSHINT;
 var _ = require('lodash');
 var ts = require('./typescript');
 
+var defaultSuccessfulResponseType = "any";
+
 var normalizeName = function(id) {
     return id.replace(/\.|\-|\{|\}/g, '_');
 };
@@ -76,6 +78,13 @@ var getViewForSwagger2 = function(opts, type){
                 }
             }
 					
+            var successfulResponseType;
+            try {
+                successfulResponseType = ts.convertType(op.responses["200"]).target || defaultSuccessfulResponseType;
+            } catch (error) {
+                successfulResponseType = defaultSuccessfulResponseType;
+            }
+
             var method = {
                 path: path,
                 className: opts.className,
@@ -90,7 +99,8 @@ var getViewForSwagger2 = function(opts, type){
 							  isSecureApiKey: secureTypes.indexOf('apiKey') !== -1,
 							  isSecureBasic: secureTypes.indexOf('basic') !== -1,
                 parameters: [],
-                headers: []
+                headers: [],
+                successfulResponseType
             };
 					  if(method.isSecure && method.isSecureToken) {
 					      data.isSecureToken = method.isSecureToken;
@@ -182,7 +192,8 @@ var getViewForSwagger1 = function(opts, type){
         moduleName: opts.moduleName,
         className: opts.className,
         domain: swagger.basePath ? swagger.basePath : '',
-        methods: []
+        methods: [],
+        successfulResponseType: defaultSuccessfulResponseType
     };
     swagger.apis.forEach(function(api){
         api.operations.forEach(function(op){


### PR DESCRIPTION
I encountered a case where I needed to access the typescript type of a successful response in my mustache templates. This is currently not supported, so this PR adds a successfulResponseType variable that can be accessed in the templates, like all of the other mustache variables