### PR TITLE
Fixes issue with duplicate method names

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -32,6 +32,7 @@ var getPathToMethodName = function(opts, m, path){
 
 var getViewForSwagger2 = function(opts, type){
     var swagger = opts.swagger;
+    var methods = [];
     var authorizedMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'COPY', 'HEAD', 'OPTIONS', 'LINK', 'UNLIK', 'PURGE', 'LOCK', 'UNLOCK', 'PROPFIND'];
     var data = {
         isNode: type === 'node' || type === 'react',
@@ -75,11 +76,25 @@ var getViewForSwagger2 = function(opts, type){
 									}
                 }
             }
-					
+            var methodName = (op.operationId ? normalizeName(op.operationId) : getPathToMethodName(opts, m, path));
+            // Make sure the method name is unique
+            if(methods.indexOf(methodName) !== -1) {
+              var i = 1;
+              while(true) {
+                if(methods.indexOf(methodName + '_' + i) !== -1) {
+                  i++;
+                } else {
+                  methodName = methodName + '_' + i;
+                  break;
+                }
+              }
+            }
+            methods.push(methodName);
+
             var method = {
                 path: path,
                 className: opts.className,
-                methodName:  op.operationId ? normalizeName(op.operationId) : getPathToMethodName(opts, m, path),
+                methodName: methodName,
                 method: M,
                 isGET: M === 'GET',
                 isPOST: M === 'POST',


### PR DESCRIPTION
Had some trouble with a swagger spec that uses a parameter in the url, resulting in the same `operationId`

This PR makes sure an addition `_1` or `_2` etc is appended