### PR TITLE
Increase max lint errors

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -284,7 +284,7 @@ var getCode = function(opts, type) {
         strict: true,
         trailing: true,
         smarttabs: true,
-        maxerr: 999
+        maxerr: 9999
     };
     if (opts.esnext) {
         lintOptions.esnext = true;


### PR DESCRIPTION
The lint error limit of 999 is preventing use of this dependency in large codebases. I have increased the limit to 9999. This is still a magic and arbitrary number, and it's very possible this limit will need to be revisited in the future.