### PR TITLE
Add single quotation mark into default value

### DIFF
--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -37,7 +37,7 @@
                 {{/isPatternType}}
                 {{#default}}
                     /** set default value **/
-                    queryParameters['{{&name}}'] = {{&default}};
+                    queryParameters['{{&name}}'] = '{{&default}}';
                 {{/default}}
 
                 {{^isPatternType}}


### PR DESCRIPTION
I found a bug when I used the following swagger definition of Microsoft Cognitive Services.

https://westus.dev.cognitive.microsoft.com/docs/services/56f91f2d778daf23d8ec6739/export?DocumentFormat=Swagger&ApiName=Computer%20Vision%20API%20-%20v1.0

I think that single quotation mark is needed in the default value of parameter.
Could you check my code and solve it?