### PR TITLE
Allow optional object properties for typescript

### DIFF
--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -61,6 +61,12 @@ function convertType(swaggerType, swagger) {
             _.forEach(swaggerType.properties, function (propertyType, propertyName) {
                 var property = convertType(propertyType);
                 property.name = propertyName;
+
+                property.optional = true;
+                if (swaggerType.required && swaggerType.required.indexOf(propertyName) !== -1) {
+                  property.optional = false;
+                }
+
                 typespec.properties.push(property);
             });
         }
@@ -79,4 +85,3 @@ function convertType(swaggerType, swagger) {
 }
 
 module.exports.convertType = convertType;
-

--- a/templates/type.mustache
+++ b/templates/type.mustache
@@ -4,7 +4,7 @@
 <%#isRef%><%target%><%/isRef%><%!
 %><%#isAtomic%><%&tsType%><%/isAtomic%><%!
 %><%#isObject%>{<%#properties%>
-'<%name%>': <%>type%><%/properties%>
+'<%name%>'<%#optional%>?<%/optional%>: <%>type%><%/properties%>
 }<%/isObject%><%!
 %><%#isArray%>Array<<%#elementType%><%>type%><%/elementType%>>|<%#elementType%><%>type%><%/elementType%><%/isArray%>
 <%={{ }}=%>


### PR DESCRIPTION
This marks object properties as optional unless they are explicitly marked as required in the swagger file.

So this: 

```
mytype: 
  required: 
    - foo
  properties:
    - foo
      - type: string
    - bar
      - type: string
```

now becomes this (notice the question mark)

```
type mytype = {
    'foo': string
    'bar' ? : string
};
```