### PR TITLE
Change reject object to Error object

### DIFF
--- a/templates/node-class.mustache
+++ b/templates/node-class.mustache
@@ -83,7 +83,10 @@
                 } else if(response.statusCode >= 200 && response.statusCode <= 299) {
                     deferred.resolve({ response: response, body: body });
                 } else {
-                    deferred.reject({ response: response, body: body });
+                    {{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} err = new Error('Unexpected status code:' + response.statusCode);
+                    err.body = body;
+                    err.response = response;
+                    deferred.reject(err);
                 }
             }
         });


### PR DESCRIPTION
I updated this reject to be of type Error to be consistent with other reject statements. This prevents you from having to interpret the error before logging as this object is pretty large and results in long log statements.

Also - thanks for this project! It has been a lot of help.