### PR TITLE
Added isLast flag for parameters

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -134,7 +134,7 @@ var getViewForSwagger2 = function(opts, type){
                 params = op.parameters;
             }
             params = params.concat(globalParams);
-            _.forEach(params, function(parameter) {
+            _.forEach(params, function(parameter, index) {
                 //Ignore parameters which contain the x-exclude-from-bindings extension
                 if(parameter['x-exclude-from-bindings'] === true) {
                     return;
@@ -171,6 +171,7 @@ var getViewForSwagger2 = function(opts, type){
                 }
                 parameter.tsType = ts.convertType(parameter);
                 parameter.cardinality = parameter.required ? '' : '?';
+                parameter.isLast = index === params.length - 1;
                 method.parameters.push(parameter);
             });
             data.methods.push(method);


### PR DESCRIPTION
I was trying to make the list of separate arguments in generated functions:

```js
Swagger.prototype.login = function(email, password) {
    ...
}
```

instead of one object:

```js
Swagger.prototype.login = function(parameters) {
    ...
}
```

but problem with the last comma cannot be fixed without this flag. A lot of tutorials for Mustache says that this checks should be executed when data is preparing.

Also I want to hear your opinion about [this method template](https://gist.github.com/atnartur/32c5699f196d3d83677b53a062f361eb) that generated code as I shown above. Can I implement this with adding new argument?