### PR TITLE
Support for customizable authorized methods

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -33,7 +33,7 @@ var getPathToMethodName = function(opts, m, path){
 var getViewForSwagger2 = function(opts, type){
     var swagger = opts.swagger;
     var methods = [];
-    var authorizedMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'COPY', 'HEAD', 'OPTIONS', 'LINK', 'UNLIK', 'PURGE', 'LOCK', 'UNLOCK', 'PROPFIND'];
+    var authorizedMethods = (opts.authorizedMethods && opts.authorizedMethods.length > 0) ? opts.authorizedMethods : ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'COPY', 'HEAD', 'OPTIONS', 'LINK', 'UNLIK', 'PURGE', 'LOCK', 'UNLOCK', 'PROPFIND'];
     var data = {
         isNode: type === 'node' || type === 'react',
         isES6: opts.isES6 || type === 'react',
@@ -60,7 +60,7 @@ var getViewForSwagger2 = function(opts, type){
         });
         _.forEach(api, function(op, m){
             var M = m.toUpperCase();
-            if(M === '' || authorizedMethods.indexOf(M) === -1) {
+            if(M === '' || authorizedMethods.findIndex(item => M === item.toUpperCase()) === -1) {
                 return;
             }
             var secureTypes = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,15 @@
 {
   "name": "swagger-js-codegen",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSV": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1511,12 +1517,6 @@
         "verror": "1.10.0"
       }
     },
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
-      "dev": true
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -2295,11 +2295,6 @@
       "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2308,6 +2303,11 @@
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",


### PR DESCRIPTION
Adds in support for a customizable option for the codegen. This way, a user can define the exact methods to be generated from a swagger 2.0 file. A great example of this is when we have specced out CORS options in our Swagger documentation, but do not want to generate an API SDK that contains those options. 

An example of the setup would be: 

result = CodeGen.getReactCode({
	moduleName: 'Test',
	className: 'Test',
	swagger: swagger,
        authorizedMethods: ['GET', 'POST', 'PUT', 'DELETE'],
	});