### PR TITLE
Add default headers configuration.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,15 @@
 {
   "name": "swagger-js-codegen",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSV": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1511,12 +1517,6 @@
         "verror": "1.10.0"
       }
     },
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
-      "dev": true
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -2295,11 +2295,6 @@
       "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2308,6 +2303,11 @@
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -13,7 +13,7 @@
     }
     {{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} deferred = {{#isNode}}Q{{/isNode}}{{^isNode}}$q{{/isNode}}.defer();
     {{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} domain = this.domain,  path = '{{&path}}';
-    {{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} body = {}, queryParameters = {}, headers = {}, form = {};
+    {{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} body = {}, queryParameters = {}, headers = this.headers, form = {};
 
     {{#isSecure}}
         headers = this.setAuthHeaders(headers);

--- a/templates/node-class.mustache
+++ b/templates/node-class.mustache
@@ -18,6 +18,8 @@
         if(this.domain.length === 0) {
             throw new Error('Domain parameter must be specified as a string.');
         }
+        {{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} headers = (typeof options === 'object') ? options.headers : {};
+        this.headers = headers ? headers : {};
         {{#isSecure}}
             {{#isSecureToken}}
                 this.token = (typeof options === 'object') ? (options.token ? options.token : {}) : {};


### PR DESCRIPTION
In general, all the endpoints in an API shear the same headers,
and these headers are not really part of the domain contract and
are used for protocol or context usages, so define them as header
parameters is cumbersome, on the contrary, define them at
configuration time feels great.