### PR TITLE
Wrap default parameters in a string if the input is type of string

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -169,6 +169,9 @@ var getViewForSwagger2 = function(opts, type){
                 } else if(parameter.in === 'formData'){
                     parameter.isFormParameter = true;
                 }
+                if(parameter.type === 'string') {
+                  parameter.isString = true;
+                }
                 parameter.tsType = ts.convertType(parameter);
                 parameter.cardinality = parameter.required ? '' : '?';
                 method.parameters.push(parameter);
@@ -245,6 +248,9 @@ var getViewForSwagger1 = function(opts, type){
                     parameter.isHeaderParameter = true;
                 } else if(parameter.paramType === 'form'){
                     parameter.isFormParameter = true;
+                }
+                if(parameter.type === 'string') {
+                  parameter.isString = true;
                 }
             });
             data.methods.push(method);

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -37,7 +37,12 @@
                 {{/isPatternType}}
                 {{#default}}
                     /** set default value **/
-                    queryParameters['{{&name}}'] = {{&default}};
+                    {{#isString}}
+                      queryParameters['{{&name}}'] = '{{default}}';
+                    {{/isString}}
+                    {{^isString}}
+                      queryParameters['{{&name}}'] = {{default}};
+                    {{/isString}}
                 {{/default}}
 
                 {{^isPatternType}}
@@ -47,11 +52,11 @@
                 {{/isPatternType}}
             {{/isSingleton}}
         {{/isQueryParameter}}
-        
+
         {{#isPathParameter}}
             path = path.replace('{{=<% %>=}}{<%&name%>}<%={{ }}=%>', parameters['{{&camelCaseName}}']);
         {{/isPathParameter}}
-        
+
         {{#isHeaderParameter}}
             {{#isSingleton}}
                 headers['{{&name}}'] = '{{&singleton}}';
@@ -62,7 +67,7 @@
                 }
             {{/isSingleton}}
         {{/isHeaderParameter}}
-        
+
         {{#isBodyParameter}}
             if(parameters['{{&camelCaseName}}'] !== undefined){
                 body = parameters['{{&camelCaseName}}'];
@@ -86,7 +91,7 @@
             return deferred.promise;
         }
         {{/required}}
- 
+
     {{/parameters}}
     queryParameters = mergeQueryParams(parameters, queryParameters);
 


### PR DESCRIPTION
This fixes an issue where default parameters if they were strings were output as an unwrapped string. This could potentially have some more complex a check rather than just looking for the parameter type, but this should cover most cases assuming valid parameters are used.