### PR TITLE
Allow generate a default domain without basepath property

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -30,6 +30,14 @@ var getPathToMethodName = function(opts, m, path){
     return m.toLowerCase() + result[0].toUpperCase() + result.substring(1);
 };
 
+var getDefaultDomain = function(swagger) {
+    var domain  = swagger.schemes[0];
+    domain += '://';
+    domain += swagger.host;
+    domain += _.has(swagger, 'basePath') ? swagger.basePath.replace(/\/+$/g,'') : '';
+    return domain;
+}
+
 var getViewForSwagger2 = function(opts, type){
     var swagger = opts.swagger;
     var methods = [];
@@ -42,7 +50,7 @@ var getViewForSwagger2 = function(opts, type){
         moduleName: opts.moduleName,
         className: opts.className,
         imports: opts.imports,
-        domain: (swagger.schemes && swagger.schemes.length > 0 && swagger.host && swagger.basePath) ? swagger.schemes[0] + '://' + swagger.host + swagger.basePath.replace(/\/+$/g,'') : '',
+        domain: (swagger.schemes && swagger.schemes.length > 0 && swagger.host) ? getDefaultDomain(swagger) : '',
         methods: [],
         definitions: []
     };

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -36,7 +36,7 @@ var getDefaultDomain = function(swagger) {
     domain += swagger.host;
     domain += _.has(swagger, 'basePath') ? swagger.basePath.replace(/\/+$/g,'') : '';
     return domain;
-}
+};
 
 var getViewForSwagger2 = function(opts, type){
     var swagger = opts.swagger;


### PR DESCRIPTION
## Problem
It's not possible to generate a default domain without sending the basepath parameter, this is not a mandatory parameter in the swagger definition if basePath is not specified, it defaults to /.

## Solution
Remove as required the basepath property to generate a default domain