### PR TITLE
Add support for ES6 promises and modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ className:
 domain:
   type: string
   description: If all options defined: swagger.schemes[0] + '://' + swagger.host + swagger.basePath
+useES6Promises:
+  type: boolean
+  description: false unless enabled in your options field, removes Q and enables regular ES6 promises in Node or React code
+useES6Modules:
+  type: boolean
+  description: false unless enabled in your options field, removes exports-loader and enables regular ES6 module exports in Node or React code
 methods:
   type: array
   items:

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -269,6 +269,8 @@ var getCode = function(opts, type) {
         opts.template.method = opts.template.method || fs.readFileSync(templates + (type === 'typescript' ? 'typescript-' : '') + 'method.mustache', 'utf-8');
         if(type === 'typescript') {
             opts.template.type = opts.template.type || fs.readFileSync(templates + 'type.mustache', 'utf-8');
+        } else if(type === 'angular') {
+            opts.useES6Promises = false;
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -632,7 +632,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-      "dev": true,
       "requires": {
         "is-number": "^2.1.0",
         "isobject": "^2.0.0",
@@ -1200,8 +1199,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -1280,7 +1278,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -1351,7 +1348,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
       "requires": {
         "isarray": "1.0.0"
       },
@@ -1359,8 +1355,7 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
       }
     },
@@ -1463,7 +1458,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -1554,8 +1548,7 @@
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-      "dev": true
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
     },
     "meow": {
       "version": "3.7.0",
@@ -1937,7 +1930,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
-      "dev": true,
       "requires": {
         "is-number": "^4.0.0",
         "kind-of": "^6.0.0",
@@ -1947,14 +1939,12 @@
         "is-number": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -2058,14 +2048,12 @@
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -632,6 +632,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "dev": true,
       "requires": {
         "is-number": "^2.1.0",
         "isobject": "^2.0.0",
@@ -1199,7 +1200,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -1278,6 +1280,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -1348,6 +1351,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
       "requires": {
         "isarray": "1.0.0"
       },
@@ -1355,7 +1359,8 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         }
       }
     },
@@ -1458,6 +1463,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -1548,7 +1554,8 @@
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
     },
     "meow": {
       "version": "3.7.0",
@@ -1930,6 +1937,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+      "dev": true,
       "requires": {
         "is-number": "^4.0.0",
         "kind-of": "^6.0.0",
@@ -1939,12 +1947,14 @@
         "is-number": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -2048,12 +2058,14 @@
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -11,7 +11,7 @@
     if(parameters === undefined) {
         parameters = {};
     }
-    {{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} deferred = {{#isNode}}Q{{/isNode}}{{^isNode}}$q{{/isNode}}.defer();
+    {{^useES6Promises}}{{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} deferred = {{#isNode}}Q{{/isNode}}{{^isNode}}$q{{/isNode}}.defer();{{/useES6Promises}}
     {{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} domain = this.domain,  path = '{{&path}}';
     {{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} body = {}, queryParameters = {}, headers = {}, form = {};
 
@@ -82,15 +82,26 @@
 
         {{#required}}
         if(parameters['{{&camelCaseName}}'] === undefined){
-            deferred.reject(new Error('Missing required {{&paramType}} parameter: {{&camelCaseName}}'));
+            {{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} error = new Error('Missing required {{&paramType}} parameter: {{&camelCaseName}}');
+            {{#useES6Promises}}
+            throw error;
+            {{/useES6Promises}}
+            {{^useES6Promises}}
+            deferred.reject(error);
             return deferred.promise;
+            {{/useES6Promises}}
         }
         {{/required}}
  
     {{/parameters}}
     queryParameters = mergeQueryParams(parameters, queryParameters);
-
+    
+    {{#useES6Promises}}
+    return this.request('{{method}}', domain + path, parameters, body, headers, queryParameters, form);
+    {{/useES6Promises}}
+    {{^useES6Promises}}
     this.request('{{method}}', domain + path, parameters, body, headers, queryParameters, form, deferred);
 
     return deferred.promise;
+    {{/useES6Promises}}
  };

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -96,12 +96,7 @@
     {{/parameters}}
     queryParameters = mergeQueryParams(parameters, queryParameters);
     
-    {{#useES6Promises}}
-    return this.request('{{method}}', domain + path, parameters, body, headers, queryParameters, form);
-    {{/useES6Promises}}
-    {{^useES6Promises}}
-    this.request('{{method}}', domain + path, parameters, body, headers, queryParameters, form, deferred);
+    {{#useES6Promises}}return {{/useES6Promises}}this.request('{{method}}', domain + path, parameters, body, headers, queryParameters, form{{^useES6Promises}}, deferred{{/useES6Promises}});
 
-    return deferred.promise;
-    {{/useES6Promises}}
+    {{^useES6Promises}}return deferred.promise;{{/useES6Promises}}
  };

--- a/templates/node-class.mustache
+++ b/templates/node-class.mustache
@@ -10,7 +10,7 @@
     'use strict';
 
     {{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} request = require('request');
-    {{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} Q = require('q');
+    {{^useES6Promises}}{{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} Q = require('q');{{/useES6Promises}}
 
     function {{&className}}(options){
         {{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} domain = (typeof options === 'object') ? options.domain : options;
@@ -53,9 +53,9 @@
      * @param {object} headers - header parameters
      * @param {object} queryParameters - querystring parameters
      * @param {object} form - form data object
-     * @param {object} deferred - promise object
+     {{^useES6Promises}}* @param {object} deferred - promise object{{/useES6Promises}}
      */
-    {{&className}}.prototype.request = function(method, url, parameters, body, headers, queryParameters, form, deferred){
+    {{&className}}.prototype.request = function(method, url, parameters, body, headers, queryParameters, form{{^useES6Promises}}, deferred{{/useES6Promises}}){
         {{#isES6}}let{{/isES6}}{{^isES6}}var{{/isES6}} req = {
             method: method,
             uri: url,
@@ -69,9 +69,10 @@
         if(typeof(body) === 'object' && !(body instanceof Buffer)) {
             req.json = true;
         }
+        {{#useES6Promises}}return new Promise((resolve, reject) => { {{/useES6Promises}}
         request(req, function(error, response, body){
             if(error) {
-                deferred.reject(error);
+                {{^useES6Promises}}deferred.{{/useES6Promises}}reject(error);
             } else {
                 if(/^application\/(.*\\+)?json/.test(response.headers['content-type'])) {
                     try {
@@ -79,14 +80,15 @@
                     } catch(e) {}
                 }
                 if(response.statusCode === 204) {
-                    deferred.resolve({ response: response });
+                    {{^useES6Promises}}deferred.{{/useES6Promises}}resolve({ response: response });
                 } else if(response.statusCode >= 200 && response.statusCode <= 299) {
-                    deferred.resolve({ response: response, body: body });
+                    {{^useES6Promises}}deferred.{{/useES6Promises}}resolve({ response: response, body: body });
                 } else {
-                    deferred.reject({ response: response, body: body });
+                    {{^useES6Promises}}deferred.{{/useES6Promises}}reject({ response: response, body: body });
                 }
             }
         });
+        {{#useES6Promises}}});{{/useES6Promises}}
     };
 
     {{#isSecure}}
@@ -171,4 +173,9 @@
     return {{&className}};
 })();
 
+{{#useES6Modules}}
+export default {{&className}};
+{{/useES6Modules}}
+{{^useES6Modules}}
 exports.{{&className}} = {{&className}};
+{{/useES6Modules}}

--- a/templates/react-class.mustache
+++ b/templates/react-class.mustache
@@ -1,6 +1,6 @@
 /*jshint esversion: 6 */
 /*global fetch, btoa */
-import Q from 'q';
+{{^useES6Promises}}import Q from 'q';{{/useES6Promises}}
 /**
  * {{&description}}
  * @class {{&className}}
@@ -62,9 +62,11 @@ let {{&className}} = (function(){
       * @param {object} headers - header parameters
       * @param {object} queryParameters - querystring parameters
       * @param {object} form - form data object
+      {{^useES6Promises}}
       * @param {object} deferred - promise object
+      {{/useES6Promises}}
       */
-    {{&className}}.prototype.request = function(method, url, parameters, body, headers, queryParameters, form, deferred){
+    {{&className}}.prototype.request = function(method, url, parameters, body, headers, queryParameters, form{{^useES6Promises}}, deferred{{/useES6Promises}}){
         const queryParams = queryParameters && Object.keys(queryParameters).length ? serializeQueryParams(queryParameters) : null ;
         const urlWithParams = url + (queryParams ? '?' + queryParams : '');
 
@@ -72,17 +74,17 @@ let {{&className}} = (function(){
             body = undefined;
         }
 
-        fetch(urlWithParams, {
+        {{#useES6Promises}}return {{/useES6Promises}}fetch(urlWithParams, {
             method,
             headers,
             body: JSON.stringify(body)
         }).then((response) => {
             return response.json();
-        }).then((body) => {
+        }){{^useES6Promises}}.then((body) => {
             deferred.resolve(body);
         }).catch((error) => {
             deferred.reject(error);
-        });
+        }){{/useES6Promises}};
     };
 
     {{#isSecure}}
@@ -167,4 +169,9 @@ let {{&className}} = (function(){
     return {{&className}};
 })();
 
+{{#useES6Modules}}
+export default {{&className}};
+{{/useES6Modules}}
+{{^useES6Modules}}
 exports.{{&className}} = {{&className}};
+{{/useES6Modules}}


### PR DESCRIPTION
Added `useES6Promises` and `useES6Modules` as template options for use with React and Node. This allows `exports-loader` and `Q` to be removed as dependencies in environments with ES6 support.