### PR TITLE
fix untyped objects in flow

### DIFF
--- a/templates/flow-type.mustache
+++ b/templates/flow-type.mustache
@@ -2,7 +2,8 @@
 {{=<% %>=}}
 <%#simpleFlowType%><%&simpleFlowType%><%/simpleFlowType%><%!
 %><%#isObject%>{<%#properties%>
-<%name%><%#optional%>?<%/optional%>: <%>type%>,<%/properties%>
+<%name%><%#optional%>?<%/optional%>: <%>type%>,<%/properties%><%!
+%><%^properties%>...<%/properties%>
 }<%/isObject%><%!
 %><%#isArray%>Array<<%#elementType%><%>type%><%/elementType%>><%/isArray%>
 <%={{ }}=%>


### PR DESCRIPTION
If we have an object with no specified properties, the generated flow type results into `{}`, which means this object cannot have any fields.
Instead, we want to allow the object to have *any* fields, so the right type should be `{...}`