### PR TITLE
Make tags available

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## We are looking for a new maintainer
 
 This project is no longer actively maintained by its creator. Please let us know if you would like to become a maintainer.
-At the time we wrote this package, the swagger didn't have generators for JavaScript nor TypeScript. Now there are [great alternatives of this package available](https://github.com/swagger-api/swagger-codegen). 
+At the time we wrote this package, the swagger didn't have generators for JavaScript nor TypeScript. Now there are [great alternatives of this package available](https://github.com/swagger-api/swagger-codegen).
 
 This package generates a nodejs, reactjs or angularjs class from a [swagger specification file](https://github.com/wordnik/swagger-spec). The code is generated using [mustache templates](https://github.com/wcandillon/swagger-js-codegen/tree/master/templates) and is quality checked by [jshint](https://github.com/jshint/jshint/) and beautified by [js-beautify](https://github.com/beautify-web/js-beautify).
 
@@ -140,6 +140,9 @@ methods:
       summary:
         type: string
         description: Provided by the 'description' or 'summary' field in the schema
+      tags:
+        type: array
+        description: Provided by the 'tags' field in the schema
       externalDocs:
         type: object
         properties:

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -132,11 +132,10 @@ var getViewForSwagger2 = function(opts, type){
                 method.headers.push({name: 'Content-Type', value: '\'' + consumes + '\'' });
             }
 
-            var tags = []
             if(_.isArray(op.tags)) {
                 // tags are just the string name at this point
                 _.forEach(op.tags, function(tagStr) {
-                    tags.push({
+                    method.tags.push({
                         name: tagStr,
                         camelCaseName: _.camelCase(tagStr)
                     })

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -100,7 +100,7 @@ var getViewForSwagger2 = function(opts, type){
                 isGET: M === 'GET',
                 isPOST: M === 'POST',
                 summary: op.description || op.summary,
-                tags: op.tags,
+                tags: [],
                 externalDocs: op.externalDocs,
                 isSecure: swagger.security !== undefined || op.security !== undefined,
 							  isSecureToken: secureTypes.indexOf('oauth2') !== -1,
@@ -131,6 +131,16 @@ var getViewForSwagger2 = function(opts, type){
             if(consumes) {
                 method.headers.push({name: 'Content-Type', value: '\'' + consumes + '\'' });
             }
+
+            var tags = []
+            if(_.isArray(op.tags)) {
+                tags = op.tags;
+            }
+
+            _.forEach(tags, function(tag) {
+                console.log('tag', tag)
+                tag.camelCaseName = _.camelCase(tag.name)
+            })
 
             var params = [];
             if(_.isArray(op.parameters)) {

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -100,6 +100,7 @@ var getViewForSwagger2 = function(opts, type){
                 isGET: M === 'GET',
                 isPOST: M === 'POST',
                 summary: op.description || op.summary,
+                tags: op.tags,
                 externalDocs: op.externalDocs,
                 isSecure: swagger.security !== undefined || op.security !== undefined,
 							  isSecureToken: secureTypes.indexOf('oauth2') !== -1,

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -134,13 +134,14 @@ var getViewForSwagger2 = function(opts, type){
 
             var tags = []
             if(_.isArray(op.tags)) {
-                tags = op.tags;
+                // tags are just the string name at this point
+                _.forEach(op.tags, function(tagStr) {
+                    tags.push({
+                        name: tagStr,
+                        camelCaseName: _.camelCase(tagStr)
+                    })
+                })
             }
-
-            _.forEach(tags, function(tag) {
-                console.log('tag', tag)
-                tag.camelCaseName = _.camelCase(tag.name)
-            })
 
             var params = [];
             if(_.isArray(op.parameters)) {

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -193,6 +193,9 @@ var getViewForSwagger2 = function(opts, type){
             _.forEach(op.responses, function(val, key) {
                 if (key.startsWith('2')) {
                     if (val.schema) {
+                        method.responseDescription = val.description;
+                        method.responseType = val.schema.type;
+                        method.responseProperties = val.schema.properties;
                         method.methodTsType = ts.convertType(val.schema);
                         method.methodFlowType = flow.convertType(val.schema);
                         method.isInlineType = true;


### PR DESCRIPTION
Includes the `tags` field from the swagger file as template variables. Format is array of objects: 

```
tags: [
  {
    name: 'house-pets',
    camelCaseName: 'housePets',
  },
  {
    name: 'zoo-pets',
    camelCaseName: 'zooPets',
  },
]
```